### PR TITLE
Fixed circular references

### DIFF
--- a/tensor_genn/layers/base_connection.py
+++ b/tensor_genn/layers/base_connection.py
@@ -1,3 +1,4 @@
+from weakref import proxy
 
 class BaseConnection(object):
 
@@ -11,13 +12,13 @@ class BaseConnection(object):
 
 
     def compile(self, tg_model):
-        self.tg_model = tg_model
+        self.tg_model = proxy(tg_model)
         self.syn = [None] * tg_model.batch_size
 
 
     def connect(self, source, target):
-        self.source = source
-        self.target = target
+        self.source = proxy(source)
+        self.target = proxy(target)
         source.downstream_connections.append(self)
         target.upstream_connections.append(self)
 

--- a/tensor_genn/layers/base_layer.py
+++ b/tensor_genn/layers/base_layer.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+from weakref import proxy
 
 class BaseLayer(object):
 
@@ -19,7 +19,7 @@ class BaseLayer(object):
 
     def compile(self, tg_model):
         print('compiling layer <{}>'.format(self.name))
-        self.tg_model = tg_model
+        self.tg_model = proxy(tg_model)
         self.nrn = [None] * tg_model.batch_size
 
         # Add batch neuron populations


### PR DESCRIPTION
Seemingly running into these is my new Python curse. Basically, ``tensor_genn.Model`` were not being destroyed because there were circular dependencies between connections, layers and models. My understanding of what objects should 'own' others in tensor genn is a little hazy so this may not be entirely correct (in case you've forgotten, I wrote some explanation of these issues at https://github.com/genn-team/genn/pull/335)