### PR TITLE
Fixed bugs with spike recording

### DIFF
--- a/examples/simple_cnn.py
+++ b/examples/simple_cnn.py
@@ -58,6 +58,5 @@ if __name__ == '__main__':
     # Report ML GeNN model results
     print('Accuracy of SimpleCNN GeNN model: {}%'.format(acc[0]))
     if args.plot:
-        names = ['input_nrn'] + [name + '_nrn' for name in mlg_model.layer_names]
-        neurons = [mlg_model.g_model.neuron_populations[name] for name in names]
+        neurons = [l.neurons.nrn for l in mlg_model.layers]
         raster_plot(spk_i, spk_t, neurons)

--- a/examples/vgg16.py
+++ b/examples/vgg16.py
@@ -146,6 +146,5 @@ if __name__ == '__main__':
     # Report ML GeNN model results
     print('Accuracy of VGG16 GeNN model: {}%'.format(acc[0]))
     if args.plot:
-        names = ['input_nrn'] + [name + '_nrn' for name in mlg_model.layer_names]
-        neurons = [mlg_model.g_model.neuron_populations[name] for name in names]
+        neurons = [l.neurons.nrn for l in mlg_model.layers]
         raster_plot(spk_i, spk_t, neurons)

--- a/ml_genn/model.py
+++ b/ml_genn/model.py
@@ -175,7 +175,7 @@ class Model(object):
 
         n_correct = [0] * len(self.outputs)
         accuracy = [0] * len(self.outputs)
-        all_spikes = [[[]] * len(self.layers)] * len(save_samples)
+        all_spikes = [[[] for i,_ in enumerate(self.layers)] for s in save_samples]
 
         # Process batches
         progress = tqdm(total=n_samples)
@@ -203,7 +203,9 @@ class Model(object):
                     for l, layer in enumerate(self.layers):
                         nrn = layer.neurons.nrn
                         nrn.pull_current_spikes_from_device()
-                        all_spikes[k][l].append(np.copy(nrn.current_spikes[batch_i]))
+                        all_spikes[k][l].append(np.copy(
+                            nrn.current_spikes[batch_i] if self.g_model.batch_size > 1
+                            else nrn.current_spikes))
 
             # Compute accuracy
             for output_i in range(len(self.outputs)):
@@ -223,8 +225,8 @@ class Model(object):
         progress.close()
 
         # Create spike index and time lists
-        spike_i = [[[]] * len(self.layers)] * len(save_samples)
-        spike_t = [[[]] * len(self.layers)] * len(save_samples)
+        spike_i = [[None for i,_ in enumerate(self.layers)] for s in save_samples]
+        spike_t = [[None for i,_ in enumerate(self.layers)] for s in save_samples]
         for i in range(len(save_samples)):
             for j in range(len(self.layers)):
                 spikes = all_spikes[i][j]

--- a/ml_genn/utils/plotting.py
+++ b/ml_genn/utils/plotting.py
@@ -3,7 +3,7 @@ import math
 
 def raster_plot(spike_ids, spike_times, neuron_pops):
     for st, si in zip(spike_times, spike_ids):
-        fig, ax = plt.subplots(math.ceil(len(neuron_pops) / 3.0), 3)
+        fig, ax = plt.subplots(math.ceil(len(neuron_pops) / 3.0), 3, sharex="col")
         ax = trim_ax(ax, len(neuron_pops))
         for ax, (j, npop) in zip(ax, enumerate(neuron_pops)):
             ax.set_title(npop.name + ' ' + str(len(st[j])))


### PR DESCRIPTION
In the process of trying to add FS neurons to mlGeNN, I hit some problems with recording which I tried to fix here (at some point mlGeNN should be updated to use the [new spike recording system](https://github.com/genn-team/genn/pull/372) but that's one for another day):

* Use correct syntax for accessing neuron populations
* Correctly handle batching when accessing current spikes
* Fixed classic Python bug involving empty list initialization

The classic bug to which I refer is this:
```python
x = [[]] * 4
x[0].append(5)
print(x)
```
which actually creates a list consisting of 4 references to the same (initially) empty list so the result is:
```
[[5], [5], [5], [5]]
```
standard (minimally ugly) solution which  I've applied in Model is to to do something like:
```python
x = [[] for _ in range(4)]
```
