### PR TITLE
Correct few-spike conversion of branching networks

### DIFF
--- a/ml_genn/converters/data_norm.py
+++ b/ml_genn/converters/data_norm.py
@@ -63,7 +63,7 @@ class DataNorm(object):
                 'Data-Norm converter: {} layers are not supported'.format(
                     tf_layer.__class__.__name__))
 
-    def create_input_neurons(self, pre_compile_output):
+    def create_input_neurons(self, pre_convert_output):
         if self.input_type == InputType.SPIKE:
             return SpikeInputNeurons(signed_spikes=self.signed_input)
         elif self.input_type == InputType.POISSON:
@@ -71,10 +71,10 @@ class DataNorm(object):
         elif self.input_type == InputType.IF:
             return IFInputNeurons()
 
-    def create_neurons(self, tf_layer, pre_compile_output):
-        return IFNeurons(threshold=pre_compile_output.thresholds[tf_layer])
+    def create_neurons(self, tf_layer, pre_convert_output):
+        return IFNeurons(threshold=pre_convert_output.thresholds[tf_layer])
 
-    def pre_compile(self, tf_model):
+    def pre_convert(self, tf_model):
         # Get output functions for weighted layers.
         idx = [i for i, layer in enumerate(tf_model.layers)
                if len(layer.get_weights()) > 0]
@@ -104,6 +104,9 @@ class DataNorm(object):
                       in zip(weighted_layers, applied_factors)}
 
         return PreCompileOutput(thresholds=thresholds)
+    
+    def pre_compile(self, mlg_model):
+        pass
 
     def post_compile(self, mlg_model):
         pass

--- a/ml_genn/converters/few_spike.py
+++ b/ml_genn/converters/few_spike.py
@@ -60,19 +60,19 @@ class FewSpike(object):
                 'Few-Spike converter: {} layers are not supported'.format(
                     tf_layer.__class__.__name__))
 
-    def create_input_neurons(self, pre_compile_output):
-        alpha = (self.alpha if pre_compile_output.max_input is None 
-                 else float(np.ceil(pre_compile_output.max_input)))
+    def create_input_neurons(self, pre_convert_output):
+        alpha = (self.alpha if pre_convert_output.max_input is None 
+                 else float(np.ceil(pre_convert_output.max_input)))
         return FSReluInputNeurons(self.K, alpha, self.signed_input)
 
-    def create_neurons(self, tf_layer, pre_compile_output):
+    def create_neurons(self, tf_layer, pre_convert_output):
         # Lookup optimised alpha value for neuron
-        alpha = (float(np.ceil(pre_compile_output.max_activations[tf_layer]))
-                 if tf_layer in pre_compile_output.max_activations 
+        alpha = (float(np.ceil(pre_convert_output.max_activations[tf_layer]))
+                 if tf_layer in pre_convert_output.max_activations 
                  else self.alpha)
         return FSReluNeurons(self.K, alpha)
     
-    def pre_compile(self, tf_model):
+    def pre_convert(self, tf_model):
         # If any normalisation data was provided
         if self.norm_data is not None:
             # Get weighted layers
@@ -103,6 +103,9 @@ class FewSpike(object):
         # Otherwise, return empty normalisation output tuple
         else:
             return PreCompileOutput(max_activations={}, max_input=None)
+
+    def pre_compile(self, mlg_model):
+        pass
     
     def post_compile(self, mlg_model):
         # do not allow multiple input or output layers

--- a/ml_genn/converters/few_spike.py
+++ b/ml_genn/converters/few_spike.py
@@ -1,6 +1,9 @@
 import numpy as np
+import sys
 import tensorflow as tf
+from copy import copy
 from collections import namedtuple
+from six import iteritems
 
 from ml_genn.layers import FSReluNeurons
 from ml_genn.layers import FSReluInputNeurons
@@ -105,7 +108,72 @@ class FewSpike(object):
             return PreCompileOutput(max_activations={}, max_input=None)
 
     def pre_compile(self, mlg_model):
-        pass
+        # Dominators of the source node of the edge-reversed DAG is set containing just it 
+        # **NOTE** reversing topologically-sorted layers is a valid topological order for the edge-reversed DAG
+        dominators = {mlg_model.layers[-1]: set((mlg_model.layers[-1],))}
+
+        # Loop through layers in reverse topological order
+        for l in reversed(mlg_model.layers[:-1]):
+            # Get intersection of all this layers predecessor
+            # **NOTE** because we're operating on the edge-reversed graph, these are downstream targets
+            downstream_dominators = set.intersection(*(dominators[d.target()] 
+                                                       for d in l.downstream_synapses))
+            dominators[l] = downstream_dominators.union((l,))
+
+        # Create dictionary of STRICT dominators by removing layers from their own dominator sets 
+        strict_dominators = {l: d.difference((l,)) 
+                             for l, d in iteritems(dominators)}
+
+        # Loop through layers
+        branches = []
+        for l in mlg_model.layers:
+            # If graph diverges at this point
+            if len(l.downstream_synapses) > 1:
+                # Loop through split layer's strict dominators
+                rejoin_points = []
+                for i in strict_dominators[l]:
+                    # If i does not strictly dominate any of split layer's other strict dominators 
+                    if not any(i in strict_dominators[j] 
+                               for j in strict_dominators[l]):
+                        rejoin_points.append(i)
+                assert len(rejoin_points) == 1
+                branches.append((l, rejoin_points[0]))
+        
+        # Loop through branches
+        for split, rejoin in branches:
+            print("Branch:", split.name, "-", rejoin.name)
+            
+            # Slice out layers starting at split point
+            split_index = mlg_model.layers.index(split)
+            branch_layers = mlg_model.layers[split_index:]
+            
+            # Initialise layer distances to min and max size for all layers between split and rejoin
+            shortest_distance = {layer: (0 if layer == split else sys.maxsize)
+                                 for layer in branch_layers}
+            longest_distance = {layer: (0 if layer == split else -sys.maxsize)
+                                 for layer in branch_layers}
+            
+            # Initialiser list of best layer predecessors
+            best_short_predecessor = {layer: None for layer in branch_layers}
+            best_long_predecessor = {layer: None for layer in branch_layers}
+            
+            # Loop through layers in branching section
+            for v in branch_layers:
+                # Loop through layer's outgoing edges
+                for s in v.downstream_synapses:
+                    # If this results in a shorter route, relax
+                    u = s.target()
+                    if shortest_distance[u] > shortest_distance[v]:
+                        shortest_distance[u] = shortest_distance[v] + 1
+                        best_short_predecessor[u] = v
+                    
+                    # If this results in a longer route, relax
+                    if longest_distance[u] < longest_distance[v]:
+                        longest_distance[u] = longest_distance[v] + 1
+                        best_long_predecessor[u] = v
+            
+            # Return shortest distance to output
+            print(shortest_distance[rejoin], longest_distance[rejoin])
     
     def post_compile(self, mlg_model):
         # do not allow multiple input or output layers

--- a/ml_genn/converters/simple.py
+++ b/ml_genn/converters/simple.py
@@ -66,7 +66,10 @@ class Simple(object):
     def create_neurons(self, tf_layer, pre_compile_output):
         return IFNeurons(threshold=1.0)
 
-    def pre_compile(self, tf_model):
+    def pre_convert(self, tf_model):
+        pass
+    
+    def pre_compile(self, mlg_model):
         pass
 
     def post_compile(self, mlg_model):

--- a/ml_genn/converters/spike_norm.py
+++ b/ml_genn/converters/spike_norm.py
@@ -60,7 +60,7 @@ class SpikeNorm(object):
                 'Spike-Norm converter: {} layers are not supported'.format(
                     tf_layer.__class__.__name__))
 
-    def create_input_neurons(self, pre_compile_output):
+    def create_input_neurons(self, pre_convert_output):
         if self.input_type == InputType.SPIKE:
             return SpikeInputNeurons(signed_spikes=self.signed_input)
         elif self.input_type == InputType.POISSON:
@@ -68,10 +68,13 @@ class SpikeNorm(object):
         elif self.input_type == InputType.IF:
             return IFInputNeurons()
 
-    def create_neurons(self, tf_layer, pre_compile_output):
+    def create_neurons(self, tf_layer, pre_convert_output):
         return IFNeurons(threshold=1.0)
 
-    def pre_compile(self, tf_model):
+    def pre_convert(self, tf_model):
+        pass
+    
+    def pre_compile(self, mlg_model):
         pass
 
     def post_compile(self, mlg_model):

--- a/ml_genn/layers/avepool2d_conv2d_synapses.py
+++ b/ml_genn/layers/avepool2d_conv2d_synapses.py
@@ -187,5 +187,5 @@ class AvePool2DConv2DSynapses(BaseSynapses):
         wu_var = {'g': init_var('Kernel', {})}
         wu_var_egp = {'g': {'kernel': self.weights.flatten() / (pool_kh * pool_kw)}}
 
-        super(AvePool2DConv2DSynapses, self).compile(mlg_model, name, conn, 0, wu_model, {}, wu_var,
+        super(AvePool2DConv2DSynapses, self).compile(mlg_model, name, conn, wu_model, {}, wu_var,
                                                      {}, {}, 'DeltaCurr', {}, {}, conn_init, wu_var_egp)

--- a/ml_genn/layers/avepool2d_dense_synapses.py
+++ b/ml_genn/layers/avepool2d_dense_synapses.py
@@ -130,5 +130,5 @@ class AvePool2DDenseSynapses(BaseSynapses):
         wu_var = {'g': wu_var_init}
         wu_var_egp = {'g': {'weights': self.weights.flatten()}}
 
-        super(AvePool2DDenseSynapses, self).compile(mlg_model, name, conn, 0, wu_model, {}, wu_var,
+        super(AvePool2DDenseSynapses, self).compile(mlg_model, name, conn, wu_model, {}, wu_var,
                                                     {}, {}, 'DeltaCurr', {}, {}, None, wu_var_egp)

--- a/ml_genn/layers/avepool2d_synapses.py
+++ b/ml_genn/layers/avepool2d_synapses.py
@@ -114,5 +114,5 @@ class AvePool2DSynapses(BaseSynapses):
         wu_model = signed_static_pulse if self.source().neurons.signed_spikes else 'StaticPulse'
         wu_var = {'g': wu_var_init}
 
-        super(AvePool2DSynapses, self).compile(mlg_model, name, conn, 0, wu_model, {}, wu_var,
+        super(AvePool2DSynapses, self).compile(mlg_model, name, conn, wu_model, {}, wu_var,
                                                {}, {}, 'DeltaCurr', {}, {}, None, {})

--- a/ml_genn/layers/base_synapses.py
+++ b/ml_genn/layers/base_synapses.py
@@ -22,7 +22,7 @@ class BaseSynapses(object):
     def get_weights(self):
         return self.weights.copy()
 
-    def compile(self, mlg_model, name, conn, delay,
+    def compile(self, mlg_model, name, conn,
                 wu_model, wu_params, wu_vars,
                 wu_pre_vars, wu_post_vars,
                 ps_model, ps_params, ps_vars,

--- a/ml_genn/layers/base_synapses.py
+++ b/ml_genn/layers/base_synapses.py
@@ -4,6 +4,7 @@ from six import iteritems
 class BaseSynapses(object):
 
     def __init__(self):
+        self.delay = 0
         self.source = None
         self.target = None
         self.weights = None
@@ -27,7 +28,7 @@ class BaseSynapses(object):
                 ps_model, ps_params, ps_vars,
                 conn_init, wu_vars_egp):
         self.syn = mlg_model.g_model.add_synapse_population(
-            name, conn, delay, self.source().neurons.nrn, self.target().neurons.nrn,
+            name, conn, self.delay, self.source().neurons.nrn, self.target().neurons.nrn,
             wu_model, wu_params, wu_vars, wu_pre_vars, wu_post_vars,
             ps_model, ps_params, ps_vars, conn_init)
         for wu_var, wu_var_egp in iteritems(wu_vars_egp):

--- a/ml_genn/layers/conv2d_synapses.py
+++ b/ml_genn/layers/conv2d_synapses.py
@@ -132,5 +132,5 @@ class Conv2DSynapses(BaseSynapses):
         wu_var = {'g': init_var('Kernel', {})}
         wu_var_egp = {'g': {'kernel': self.weights.flatten()}}
 
-        super(Conv2DSynapses, self).compile(mlg_model, name, conn, 0, wu_model, {}, wu_var,
+        super(Conv2DSynapses, self).compile(mlg_model, name, conn, wu_model, {}, wu_var,
                                             {}, {}, 'DeltaCurr', {}, {}, conn_init, wu_var_egp)

--- a/ml_genn/layers/dense_synapses.py
+++ b/ml_genn/layers/dense_synapses.py
@@ -26,5 +26,5 @@ class DenseSynapses(BaseSynapses):
         wu_model = signed_static_pulse if self.source().neurons.signed_spikes else 'StaticPulse'
         wu_var = {'g': self.weights.flatten()}
 
-        super(DenseSynapses, self).compile(mlg_model, name, conn, 0, wu_model, {}, wu_var,
+        super(DenseSynapses, self).compile(mlg_model, name, conn, wu_model, {}, wu_var,
                                            {}, {}, 'DeltaCurr', {}, {}, None, {})

--- a/ml_genn/layers/identity_synapses.py
+++ b/ml_genn/layers/identity_synapses.py
@@ -39,5 +39,5 @@ class IdentitySynapses(BaseSynapses):
         wu_model = signed_static_pulse if self.source().neurons.signed_spikes else 'StaticPulse'
         wu_var = {'g': 1.0}
 
-        super(IdentitySynapses, self).compile(mlg_model, name, conn, 0, wu_model, {}, wu_var,
+        super(IdentitySynapses, self).compile(mlg_model, name, conn, wu_model, {}, wu_var,
                                               {}, {}, 'DeltaCurr', {}, {}, conn_init, {})

--- a/ml_genn/model.py
+++ b/ml_genn/model.py
@@ -378,8 +378,8 @@ class Model(object):
             tf_out_layers_all[tf_layer] = tf_out_layers
 
 
-        # Perform any pre-compilation tasks
-        pre_compile_output = converter.pre_compile(tf_model)
+        # Perform any pre-conversion tasks
+        pre_convert_output = converter.pre_convert(tf_model)
 
         # configure model build process
         class LayerConfig(object):
@@ -434,7 +434,7 @@ class Model(object):
             config.has_activation = True
             config.name = tf_layer.name
             config.shape = tf_layer.output_shape[0][1:]
-            config.neurons = converter.create_input_neurons(pre_compile_output)
+            config.neurons = converter.create_input_neurons(pre_convert_output)
 
             config_steps.append(config)
             configs_lookups[tf_layer] = [config]
@@ -488,7 +488,7 @@ class Model(object):
                     config.is_output = len(tf_out_layers) == 0
                     config.name = tf_layer.name
                     config.shape = tf_layer.output_shape[1:]
-                    config.neurons = converter.create_neurons(tf_layer, pre_compile_output)
+                    config.neurons = converter.create_neurons(tf_layer, pre_convert_output)
                     if not tf_layer.activation is tf.keras.activations.linear:
                         config.has_activation = True
 
@@ -539,7 +539,7 @@ class Model(object):
                     config.is_output = len(tf_out_layers) == 0
                     config.name = tf_layer.name
                     config.shape = tf_layer.output_shape[1:]
-                    config.neurons = converter.create_neurons(tf_layer, pre_compile_output)
+                    config.neurons = converter.create_neurons(tf_layer, pre_convert_output)
                     if not tf_layer.activation is tf.keras.activations.linear:
                         config.has_activation = True
 
@@ -651,7 +651,7 @@ class Model(object):
                     config.name = tf_layer.name
                     config.shape = tf_layer.output_shape[1:]
                     config.has_activation = True
-                    config.neurons = converter.create_neurons(tf_layer, pre_compile_output)
+                    config.neurons = converter.create_neurons(tf_layer, pre_convert_output)
 
                     converter.validate_tf_layer(tf_layer, config)
 
@@ -730,7 +730,10 @@ class Model(object):
 
         # create model
         mlg_model = Model(mlg_model_inputs, mlg_model_outputs, name=tf_model.name)
-
+    
+        # Perform any pre-compilation tasks
+        converter.pre_compile(mlg_model)
+        
         # Compile model
         mlg_model.compile(**compile_kwargs)
 

--- a/tests/test_pipeline_depth.py
+++ b/tests/test_pipeline_depth.py
@@ -1,6 +1,6 @@
 from ml_genn.model import Model
-from ml_genn.layers import (AvePool2DConv2D, AvePool2DDense, Conv2D, Dense,
-                            InputLayer, FSReluNeurons, FSReluInputNeurons)
+from ml_genn.layers import (AvePool2D, AvePool2DConv2D, AvePool2DDense, Conv2D, 
+                            Dense, IdentitySynapses, InputLayer, FSReluNeurons, FSReluInputNeurons)
 
 def test_pipe_sequential():
     input = InputLayer("input", (28, 28, 1), neurons=FSReluInputNeurons())
@@ -23,7 +23,34 @@ def test_pipe_sequential():
     assert model.calc_pipeline_depth() == 4
 
 def test_pipe_resnet():
-    pass
-
-test_pipe_sequential()
+    input = InputLayer("input", (224, 224, 3), neurons=FSReluInputNeurons())
+    conv0 = Conv2D("conv0", 64, 7, 2, conv_padding='same', neurons=FSReluNeurons())
+    pool0 = AvePool2D("pool0", 3, neurons=FSReluNeurons())
+    conv0.connect([input])
+    pool0.connect([conv0])
+    
+    # block 1
+    block0_conv0 = Conv2D("block0_conv0", 64, 3, conv_padding='same', neurons=FSReluNeurons())
+    block0_conv1 = Conv2D("block0_conv1", 64, 3, conv_padding='same', neurons=FSReluNeurons())
+    block0_identity = IdentitySynapses()
+    block0_conv0.connect([pool0])
+    block0_conv1.connect([block0_conv0])
+    block0_identity.connect(pool0, block0_conv1)
+    
+    # block 2
+    block1_conv0 = Conv2D("block1_conv0", 64, 3, conv_padding='same', neurons=FSReluNeurons())
+    block1_conv1 = Conv2D("block1_conv1", 64, 3, conv_padding='same', neurons=FSReluNeurons())
+    block1_identity = IdentitySynapses()
+    block1_conv0.connect([block0_conv1])
+    block1_conv1.connect([block1_conv0])
+    block1_identity.connect(block0_conv1, block1_conv1)
+    
+    pool1 = AvePool2D("pool1", 56, neurons=FSReluNeurons())
+    pool1.connect([block1_conv1])
+    
+    # create model
+    model = Model([input], [pool1], name="test_pipe_resnet")
+    print(model.calc_pipeline_depth())
+    
+#test_pipe_sequential()
 test_pipe_resnet()

--- a/tests/test_pipeline_depth.py
+++ b/tests/test_pipeline_depth.py
@@ -1,0 +1,29 @@
+from ml_genn.model import Model
+from ml_genn.layers import (AvePool2DConv2D, AvePool2DDense, Conv2D, Dense,
+                            InputLayer, FSReluNeurons, FSReluInputNeurons)
+
+def test_pipe_sequential():
+    input = InputLayer("input", (28, 28, 1), neurons=FSReluInputNeurons())
+    conv0 = Conv2D("conv0", 16, 5, neurons=FSReluNeurons())
+    conv1 = AvePool2DConv2D("conv1", 8, 2, 5, neurons=FSReluNeurons())
+    dense0 = AvePool2DDense("dense0", 128, 2, neurons=FSReluNeurons())
+    dense1 = Dense("dense1", 64, neurons=FSReluNeurons())
+    output = Dense("output", 10, neurons=FSReluNeurons())
+    
+    conv0.connect([input])
+    conv1.connect([conv0])
+    dense0.connect([conv1])
+    dense1.connect([dense0])
+    output.connect([dense1])
+    
+    # create model
+    model = Model([input], [output], name="test_pipe_sequential")
+
+    # Check that pipeline depth is correct
+    assert model.calc_pipeline_depth() == 4
+
+def test_pipe_resnet():
+    pass
+
+test_pipe_sequential()
+test_pipe_resnet()


### PR DESCRIPTION
Sorry for the chain of PRs but I wanted to build on some previous stuff. This PR fixes three issues with few-spike conversion of branching networks e.g. ResNets:

1. (Axonal) delays need to be inserted to 'balance' branches. I use the approach described [here](https://stackoverflow.com/questions/59656961/in-a-dag-how-to-find-vertices-where-paths-converge) to find where branches split and rejoin. Because the graph is a DAG, the thrilling named dominator graph can be trivially calculated directly from the [definition ](https://en.wikipedia.org/wiki/Dominator_(graph_theory)). Between each split and rejoin point, we then find all the branches and insert delays to make them all take the same time.
2. Alpha values need to be the same for all upstream populations connecting to another population. As, after 1, we know all the 'rejoin' points in the graph we can simply take the max of alpha values here.
3. The pipeline depth calculation required to read out the output at the correct time and run the network for long enough was broken. After 1, delays through all paths in the network are balanced so, assuming a single input and output, this is as simple as following an arbitrary path through the downstream synapses until you hit the output and summing the delays.

I started fiddling in test_pipeline_depth.py so ignore that for now - will replace it with some useful tests 😄 