### PR TITLE
Model.evaluate accepts (data, labels) iterator.

### DIFF
--- a/ml_genn/model.py
+++ b/ml_genn/model.py
@@ -167,8 +167,10 @@ class Model(object):
         """Evaluate the accuracy of a GeNN model
 
         Args:
-        data          --  list of data for each input layer
-        labels        --  list of labels for each output layer
+        data          --  list of data for each input layer,
+                          or (data, labels) iterator if labels is None
+        labels        --  list of labels for each output layer,
+                          or None if data is a (data, labels) iterator
         time          --  sample presentation time (msec)
 
         Keyword args:
@@ -179,6 +181,12 @@ class Model(object):
         spike_i       --  list of spike indices for each sample index in save_samples
         spike_t       --  list of spike times for each sample index in save_samples
         """
+
+        # Convert (data, labels) iterator to data and labels arrays
+        if labels == None and hasattr(data, '__next__'):
+            data_new, labels_new = zip(*data)
+            data = [np.array(data_new)]
+            labels = [np.array(labels_new)]
 
         # Input sanity check
         n_samples = data[0].shape[0]


### PR DESCRIPTION
Don't merge yet. Needs discussion.

This change allows `Model.evaluate` to accept a (data, labels) iterator, like something that might be emitted from a `tensorflow.data.Dataset.as_numpy_iterator` object. To do this, one passes the (data, labels) iterator in the `data` arg of `evaluate`, and sets the `labels` arg to `None`.

Some notes:

1) This will load the entire validation dataset into memory. As @neworderofjamie noted, this is not a problem in our case, since ImageNet validation set is 50000 images only. Could be a problem for others, or for other datasets. Should we change all the code to work with iterators? Then we won't know the dataset length inside our code.

2) Currently only working for one iterator, for one input and output layer. If an iterator only gives a (data, label) pair for one input and output layer, then *n* iterators serves exactly *n* input layers and exactly *n* output layers. Is that really what we want?
