### PR TITLE
Enable autodoc in readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,9 +30,11 @@ author = "James Turner, Jamie Knight"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc",
-              "sphinx.ext.napoleon",
-              "sphinx_autodoc_typehints"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
+]
 
 napoleon_use_param = True
 napoleon_use_ivar = True
@@ -45,6 +47,8 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+# Mock imports for readthedocs
+autodoc_mock_imports = ["pygenn", "tensorflow"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,10 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath("../ml_genn/ml_genn"))
-sys.path.insert(0, os.path.abspath("../ml_genn_eprop/ml_genn_eprop"))
-sys.path.insert(0, os.path.abspath("../ml_genn_tf/ml_genn_tf"))
+
+sys.path.insert(0, os.path.abspath("../ml_genn"))
+sys.path.insert(0, os.path.abspath("../ml_genn_eprop"))
+sys.path.insert(0, os.path.abspath("../ml_genn_tf"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 sphinx_autodoc_typehints>=1.19,<2.0
+numpy
+tqdm


### PR DESCRIPTION
This PR should enable the docs to be built correctly in readthedocs by mocking or installing the requirements for the ml_genn packages