### PR TITLE
Spike event recording

### DIFF
--- a/ml_genn/ml_genn/callbacks/spike_recorder.py
+++ b/ml_genn/ml_genn/callbacks/spike_recorder.py
@@ -19,15 +19,15 @@ class SpikeRecorder(Callback):
         # Stash key and whether we're recording spikes or spike-like events
         self.key = key
         self._record_spike_events = record_spike_events
-        
+
         # Create example filter
         self._example_filter = ExampleFilter(example_filter)
 
         # Create neuron filter mask
         self._neuron_mask = get_neuron_filter_mask(neuron_filter,
                                                    self._pop.shape)
-        
-        # Should this Populations/Layers SpikeRecorder be the one responsible for pulling spikes?
+
+        # Should this SpikeRecorder be the one responsible for pulling spikes?
         self._pull = False
 
         # List of spike times and IDs

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -248,8 +248,9 @@ class Compiler:
                 pop.name, np.prod(pop.shape),
                 genn_neuron_model, param_vals, var_vals)
 
-            # Configure spike recording
+            # Configure spike and spike-like-event recording
             genn_pop.spike_recording_enabled = pop.record_spikes
+            genn_pop.spike_event_recording_enabled = pop.record_spike_events
 
             # Configure EGPs
             set_egp(egp_vals, genn_pop.extra_global_params)

--- a/ml_genn/ml_genn/layer.py
+++ b/ml_genn/ml_genn/layer.py
@@ -8,11 +8,14 @@ from .sequential_network import SequentialNetwork
 
 class InputLayer:
     def __init__(self, neuron: NeuronInitializer, shape: Shape = None,
-                 record_spikes: bool = False, name: Optional[str] = None):
+                 record_spikes: bool = False,
+                 record_spike_events: bool = False,
+                 name: Optional[str] = None):
         # Create population and store weak reference in class
-        population = Population(neuron, shape=shape,
-                                record_spikes=record_spikes,
-                                name=name, add_to_model=False)
+        population = Population(
+            neuron, shape=shape, record_spikes=record_spikes,
+            record_spike_events=record_spike_events,
+            name=name, add_to_model=False)
         self.population = ref(population)
 
         SequentialNetwork._add_input_layer(self, population)
@@ -22,11 +25,14 @@ class Layer:
     def __init__(self, connectivity: ConnectivityInitializer,
                  neuron: NeuronInitializer, shape: Shape = None,
                  synapse: SynapseInitializer = "delta",
-                 record_spikes: bool = False, name: Optional[str] = None):
+                 record_spikes: bool = False,
+                 record_spike_events: bool = False,
+                 name: Optional[str] = None):
         # Create population and store weak reference in class
-        population = Population(neuron, shape=shape,
-                                record_spikes=record_spikes,
-                                name=name, add_to_model=False)
+        population = Population(
+            neuron, shape=shape, record_spikes=record_spikes,
+            record_spike_events=record_spike_events,
+            name=name, add_to_model=False)
         self.population = ref(population)
 
         # If there are any preceding layers, also create

--- a/ml_genn/ml_genn/population.py
+++ b/ml_genn/ml_genn/population.py
@@ -41,13 +41,15 @@ class Population:
     _new_id = count()
     
     def __init__(self, neuron: NeuronInitializer, shape: Shape = None,
-                 record_spikes: bool = False, name: Optional[str] = None,
-                 add_to_model: bool = True):
+                 record_spikes: bool = False, 
+                 record_spike_events: bool = False,
+                 name: Optional[str] = None, add_to_model: bool = True):
         self.neuron = neuron
         self.shape = _get_shape(shape)
         self._incoming_connections = []
         self._outgoing_connections = []
         self.record_spikes = record_spikes
+        self.record_spike_events = record_spike_events
 
         # Generate unique name if required
         self.name = (f"Pop{next(Population._new_id)}" if name is None


### PR DESCRIPTION
It would have been marginally nicer to have a derived callback class for spike-event recording but that would have broken the [slightly primitive mechanism](https://github.com/genn-team/ml_genn/blob/master/ml_genn/ml_genn/utils/callback_list.py#L36-L38) for calling ``set_first`` on one callback of each type (used to only pull recording buffers once)