### PR TITLE
Compiler defaults

### DIFF
--- a/examples/eprop/latency_mnist.py
+++ b/examples/eprop/latency_mnist.py
@@ -14,6 +14,8 @@ from time import perf_counter
 from ml_genn.utils.data import (calc_latest_spike_time, calc_max_spikes,
                                 log_latency_encode_data)
 
+from ml_genn.compilers.eprop_compiler import default_params
+
 NUM_INPUT = 784
 NUM_HIDDEN = 128
 NUM_OUTPUT = 10
@@ -29,7 +31,7 @@ spikes = log_latency_encode_data(
     20.0, 51)
 
 serialiser = Numpy("latency_mnist_checkpoints")
-network = SequentialNetwork()
+network = SequentialNetwork(default_params)
 with network:
     # Populations
     input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * calc_max_spikes(spikes)),
@@ -38,9 +40,7 @@ with network:
     connectivity = (Dense(initial_hidden_weight) if SPARSITY == 1.0 
                     else FixedProbability(SPARSITY, initial_hidden_weight))
     hidden = Layer(connectivity, LeakyIntegrateFire(v_thresh=0.61, tau_mem=20.0,
-                                                    tau_refrac=5.0,
-                                                    relative_reset=True,
-                                                    integrate_during_refrac=True),
+                                                    tau_refrac=5.0),
                    NUM_HIDDEN)
     output = Layer(Dense(Normal(sd=1.0 / np.sqrt(NUM_HIDDEN))),
                    LeakyIntegrate(tau_mem=20.0, readout="sum_var"),

--- a/examples/eprop/pattern_recognition.py
+++ b/examples/eprop/pattern_recognition.py
@@ -13,6 +13,8 @@ from ml_genn.optimisers import Adam
 from time import perf_counter
 from ml_genn.utils.data import preprocess_spikes
 
+from ml_genn.compilers.eprop_compiler import default_params
+
 NUM_INPUT = 20
 NUM_HIDDEN = 256
 NUM_OUTPUT = 3
@@ -62,15 +64,13 @@ in_spike_ids = np.repeat(np.arange(NUM_INPUT), num_spikes_per_neuron)
 # Pre-process spikes
 in_spikes = preprocess_spikes(in_spike_times.flatten(), in_spike_ids, NUM_INPUT)
 
-network = Network()
+network = Network(default_params)
 with network:
     # Populations
     input = Population(SpikeInput(max_spikes=len(in_spike_ids)),
                                   NUM_INPUT, record_spikes=True)
     hidden = Population(LeakyIntegrateFire(v_thresh=0.61, tau_mem=20.0,
-                                           tau_refrac=5.0, 
-                                           relative_reset=True,
-                                           integrate_during_refrac=True),
+                                           tau_refrac=5.0),
                         NUM_HIDDEN, record_spikes=True)
     output = Population(LeakyIntegrate(tau_mem=20.0, readout="var"),
                         NUM_OUTPUT)

--- a/examples/eprop/shd_classifier.py
+++ b/examples/eprop/shd_classifier.py
@@ -14,6 +14,8 @@ from time import perf_counter
 from ml_genn.utils.data import (calc_latest_spike_time, calc_max_spikes,
                                 preprocess_tonic_spikes)
 
+from ml_genn.compilers.eprop_compiler import default_params
+
 NUM_HIDDEN = 256
 BATCH_SIZE = 512
 NUM_EPOCHS = 50
@@ -43,15 +45,13 @@ num_input = int(np.prod(dataset.sensor_size))
 num_output = len(dataset.classes)
 
 serialiser = Numpy("shd_checkpoints")
-network = Network()
+network = Network(default_params)
 with network:
     # Populations
     input = Population(SpikeInput(max_spikes=BATCH_SIZE * max_spikes),
                        num_input)
     hidden = Population(AdaptiveLeakyIntegrateFire(v_thresh=0.6,
-                                                   tau_refrac=5.0,
-                                                   relative_reset=True,
-                                                   integrate_during_refrac=True),
+                                                   tau_refrac=5.0),
                         NUM_HIDDEN)
     output = Population(LeakyIntegrate(tau_mem=20.0, readout="sum_var", num_output)
 

--- a/examples/event_prop/latency_mnist.py
+++ b/examples/event_prop/latency_mnist.py
@@ -14,6 +14,8 @@ from ml_genn.synapses import Exponential
 from time import perf_counter
 from ml_genn.utils.data import linear_latency_encode_data
 
+from ml_genn.compilers.event_prop_compiler import default_params
+
 NUM_INPUT = 784
 NUM_HIDDEN = 128
 NUM_OUTPUT = 10
@@ -31,7 +33,7 @@ spikes = linear_latency_encode_data(
     EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
 
 serialiser = Numpy("latency_mnist_checkpoints")
-network = SequentialNetwork()
+network = SequentialNetwork(default_params)
 with network:
     # Populations
     input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * NUM_INPUT),
@@ -40,13 +42,10 @@ with network:
     connectivity = (Dense(initial_hidden_weight) if SPARSITY == 1.0 
                     else FixedProbability(SPARSITY, initial_hidden_weight))
     hidden = Layer(connectivity, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                                    tau_refrac=None, 
-                                                    relative_reset=False,
-                                                    integrate_during_refrac=False,
-                                                    scale_i=True),
+                                                    tau_refrac=None),
                    NUM_HIDDEN, Exponential(5.0))
     output = Layer(Dense(Normal(mean=0.2, sd=0.37)),
-                   LeakyIntegrate(tau_mem=20.0, scale_i=True, readout="avg_var"),
+                   LeakyIntegrate(tau_mem=20.0, readout="avg_var"),
                    NUM_OUTPUT, Exponential(5.0))
 
 max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))

--- a/examples/event_prop/shd.py
+++ b/examples/event_prop/shd.py
@@ -17,6 +17,8 @@ from time import perf_counter
 from ml_genn.utils.data import (calc_latest_spike_time, calc_max_spikes,
                                 preprocess_tonic_spikes)
 
+from ml_genn.compilers.event_prop_compiler import default_params
+
 NUM_HIDDEN = 256
 BATCH_SIZE = 32
 NUM_EPOCHS = 300
@@ -48,18 +50,15 @@ num_input = int(np.prod(dataset.sensor_size))
 num_output = len(dataset.classes)
 
 serialiser = Numpy("shd_checkpoints")
-network = Network()
+network = Network(default_params)
 with network:
     # Populations
     input = Population(SpikeInput(max_spikes=BATCH_SIZE * max_spikes),
                        num_input)
     hidden = Population(LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                           tau_refrac=None,
-                                           relative_reset=False,
-                                           integrate_during_refrac=False,
-                                           scale_i=True),
+                                           tau_refrac=None),
                         NUM_HIDDEN)
-    output = Population(LeakyIntegrate(tau_mem=20.0, scale_i=True, readout="avg_var_exp_weight"),
+    output = Population(LeakyIntegrate(tau_mem=20.0, readout="avg_var_exp_weight"),
                         num_output)
 
     # Connections

--- a/ml_genn/ml_genn/compilers/eprop_compiler.py
+++ b/ml_genn/ml_genn/compilers/eprop_compiler.py
@@ -9,7 +9,8 @@ from .compiled_training_network import CompiledTrainingNetwork
 from ..callbacks import (BatchProgressBar, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnTimestepEnd)
 from ..losses import Loss, SparseCategoricalCrossentropy
-from ..neurons import AdaptiveLeakyIntegrateFire, LeakyIntegrateFire
+from ..neurons import (AdaptiveLeakyIntegrateFire, LeakyIntegrate,
+                       LeakyIntegrateFire)
 from ..optimisers import Optimiser
 from ..synapses import Delta
 from ..utils.callback_list import CallbackList
@@ -28,6 +29,15 @@ from ml_genn.optimisers import default_optimisers
 from ml_genn.losses import default_losses
 
 logger = logging.getLogger(__name__)
+
+default_params = {
+    AdaptiveLeakyIntegrateFire: {"relative_reset": True,
+                                 "integrate_during_refrac": True,
+                                 "scale_i": False},
+    LeakyIntegrate: {"scale_i": False}, 
+    LeakyIntegrateFire: {"relative_reset": True, 
+                         "integrate_during_refrac": True,
+                         "scale_i": False}}
 
 def _has_connection_to_output(pop):
     # Loop through population's outgoing connections

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -82,6 +82,12 @@ logger = logging.getLogger(__name__)
 # read and write offsets check for wraparound, this can continue forever
 # **NOTE** due to the inprecision of ASCII diagramming there are out-by-one errors in the above
 
+default_params = {
+    LeakyIntegrate: {"scale_i": True}, 
+    LeakyIntegrateFire: {"relative_reset": False, 
+                         "integrate_during_refrac": False,
+                         "scale_i": True}}
+
 def _get_tau_syn(pop):
     # Loop through incoming connections
     tau_syn = None

--- a/ml_genn/ml_genn/network.py
+++ b/ml_genn/ml_genn/network.py
@@ -24,7 +24,8 @@ class Network:
     """
     _context = None
 
-    def __init__(self):
+    def __init__(self, default_params: dict = {}):
+        self.default_params = default_params
         self.populations = []
         self.connections = []
 
@@ -66,6 +67,12 @@ class Network:
                                "inside a ``with network:`` block")
         Network._context.connections.append(conn)
 
+    @staticmethod
+    def get_default_params(type):
+        if Network._context is None:
+            return {}
+        else:
+            return Network._context.default_params.get(type, {})
 
     def __enter__(self):
         if Network._context is not None:

--- a/ml_genn/ml_genn/neurons/adaptive_leaky_integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/adaptive_leaky_integrate_fire.py
@@ -5,6 +5,7 @@ from .neuron import Neuron
 from ..utils.model import NeuronModel
 from ..utils.value import InitValue, ValueDescriptor
 
+from ..utils.decorators import network_default_params
 
 class AdaptiveLeakyIntegrateFire(Neuron):
     v_thresh = ValueDescriptor("Vthresh")
@@ -16,6 +17,7 @@ class AdaptiveLeakyIntegrateFire(Neuron):
     tau_refrac = ValueDescriptor("TauRefrac")
     tau_adapt = ValueDescriptor("Rho", lambda val, dt: np.exp(-dt / val))
 
+    @network_default_params
     def __init__(self, v_thresh: InitValue = 1.0, v_reset: InitValue = 0.0,
                  v: InitValue = 0.0, a: InitValue = 0.0, beta: InitValue = 0.0174,
                  tau_mem: InitValue = 20.0, tau_refrac: InitValue = None,

--- a/ml_genn/ml_genn/neurons/leaky_integrate.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate.py
@@ -5,11 +5,14 @@ from .neuron import Neuron
 from ..utils.model import NeuronModel
 from ..utils.value import InitValue, ValueDescriptor
 
+from ..utils.decorators import network_default_params
+
 class LeakyIntegrate(Neuron):
     v = ValueDescriptor("V")
     bias = ValueDescriptor("Bias")
     tau_mem = ValueDescriptor("Alpha", lambda val, dt: np.exp(-dt / val))
 
+    @network_default_params
     def __init__(self, v: InitValue = 0.0, bias: InitValue = 0.0,
                  tau_mem: InitValue = 20.0, scale_i : bool = False,
                  softmax: Optional[bool] = None, readout=None):

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
@@ -5,6 +5,7 @@ from .neuron import Neuron
 from ..utils.model import NeuronModel
 from ..utils.value import InitValue, ValueDescriptor
 
+from ..utils.decorators import network_default_params
 
 class LeakyIntegrateFire(Neuron):
     v_thresh = ValueDescriptor("Vthresh")
@@ -13,6 +14,7 @@ class LeakyIntegrateFire(Neuron):
     tau_mem = ValueDescriptor("Alpha", lambda val, dt: np.exp(-dt / val))
     tau_refrac = ValueDescriptor("TauRefrac")
 
+    @network_default_params
     def __init__(self, v_thresh: InitValue = 1.0, v_reset: InitValue = 0.0,
                  v: InitValue = 0.0, tau_mem: InitValue = 20.0,
                  tau_refrac: InitValue = None, relative_reset: bool = True,

--- a/ml_genn/ml_genn/sequential_network.py
+++ b/ml_genn/ml_genn/sequential_network.py
@@ -2,47 +2,45 @@ from .network import Network
 
 
 class SequentialNetwork(Network):
-    _context = None
-
-    def __init__(self):
-        super(SequentialNetwork, self).__init__()
+    def __init__(self, default_params: dict = {}):
+        super(SequentialNetwork, self).__init__(default_params)
 
         self.layers = []
 
     @staticmethod
     def _add_input_layer(layer, population):
-        if SequentialNetwork._context is None:
+        if Network._context is None:
             raise RuntimeError("InputLayer must be created "
                                "inside a ``with sequential_network:`` block")
-        SequentialNetwork._context.layers.append(layer)
-        SequentialNetwork._context.populations.append(population)
+        Network._context.layers.append(layer)
+        Network._context.populations.append(population)
 
     @staticmethod
     def _add_layer(layer, population, connection):
-        if SequentialNetwork._context is None:
+        if Network._context is None:
             raise RuntimeError("Layer must be created "
                                "inside a ``with sequential_network:`` block")
-        SequentialNetwork._context.layers.append(layer)
-        SequentialNetwork._context.populations.append(population)
-        SequentialNetwork._context.connections.append(connection)
+        Network._context.layers.append(layer)
+        Network._context.populations.append(population)
+        Network._context.connections.append(connection)
 
     @staticmethod
     def get_prev_layer():
-        if SequentialNetwork._context is None:
+        if Network._context is None:
             raise RuntimeError("Cannot get previous layer outside of a "
                                "``with sequential_network:`` block")
-        if len(SequentialNetwork._context.layers) > 0:
-            return SequentialNetwork._context.layers[-1]
+        if len(Network._context.layers) > 0:
+            return Network._context.layers[-1]
         else:
             return None
 
     def __enter__(self):
-        if SequentialNetwork._context is not None:
-            raise RuntimeError("Nested sequential networks are "
+        if Network._context is not None:
+            raise RuntimeError("Nested networks are "
                                "not currently supported")
 
-        SequentialNetwork._context = self
+        Network._context = self
 
     def __exit__(self, dummy_exc_type, dummy_exc_value, dummy_tb):
-        assert SequentialNetwork._context is not None
-        SequentialNetwork._context = None
+        assert Network._context is not None
+        Network._context = None

--- a/ml_genn/ml_genn/utils/decorators.py
+++ b/ml_genn/ml_genn/utils/decorators.py
@@ -1,0 +1,26 @@
+from ..network import Network
+
+from functools import wraps
+from inspect import signature
+
+# Based on https://stackoverflow.com/a/58983447
+def network_default_params(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        # Get list of function argument names
+        arg_names = list(signature(f).parameters.keys())
+        
+        # Slice out names of arguments (as opposed to kwargs)
+        passed_arg_names = arg_names[:len(args)]
+        
+        # Get default parameters for type
+        default_params = Network.get_default_params(type(args[0]))
+
+        # Update defaults with passed kwargs if argument wasn't provided
+        final_kwargs = {
+            key: value
+            for key, value in {**default_params, **kwargs}.items() 
+            if key not in passed_arg_names}
+            
+        return f(*args, **final_kwargs)
+    return wrapper

--- a/ml_genn/ml_genn/utils/module.py
+++ b/ml_genn/ml_genn/utils/module.py
@@ -32,7 +32,7 @@ def get_module_classes(globals: Mapping[str, Any],
             # to snake_cast and add to dictionary
             if default_constructable:
                 snake_name = camel_to_snake_pattern.sub("_", name).lower()
-                target_dict[snake_name] = obj()
+                target_dict[snake_name] = obj
     return target_dict
 
 T = TypeVar("T")
@@ -45,7 +45,7 @@ def get_object(obj, base_class: Type[T], description: str,
         return copy(obj)
     elif isinstance(obj, str):
         if obj in dictionary:
-            return copy(dictionary[obj])
+            return dictionary[obj]()
         else:
             raise RuntimeError(f"{description} object '{obj}' unknown")
     else:

--- a/ml_genn/ml_genn/utils/module.py
+++ b/ml_genn/ml_genn/utils/module.py
@@ -41,13 +41,13 @@ def get_object(obj, base_class: Type[T], description: str,
                dictionary: Mapping[str, T]) -> Optional[T]:
     if obj is None:
         return obj
-    elif isinstance(obj, base_class):
-        return copy(obj)
     elif isinstance(obj, str):
         if obj in dictionary:
             return dictionary[obj]()
         else:
             raise RuntimeError(f"{description} object '{obj}' unknown")
+    elif isinstance(obj, base_class):
+        return copy(obj)
     else:
         raise RuntimeError(f"{description} objects should be specified "
                            f"either as a string or a {description} object")

--- a/tests/ml_genn/utils/test_decorators.py
+++ b/tests/ml_genn/utils/test_decorators.py
@@ -1,0 +1,50 @@
+from ml_genn import Network
+
+from ml_genn.utils.module import get_module_classes, get_object
+from ml_genn.utils.decorators import network_default_params
+
+class Model:
+    @network_default_params
+    def __init__(self, a = 1.0, b = 0.0, c=None):
+        self.a = a
+        self.b = b
+        self.c = c
+
+default_neurons = get_module_classes(globals(), object)
+
+def test_defaults():
+    m = Model()
+    assert m.a == 1.0
+    assert m.b == 0.0
+    assert m.c == None
+
+    m = get_object("model", object, "", default_neurons)
+    assert m.a == 1.0
+    assert m.b == 0.0
+    assert m.c == None
+
+def test_network_defaults():
+    net = Network({Model: {"a": 3.0}})
+    with net:
+        m = Model()
+        assert m.a == 3.0
+        assert m.b == 0.0
+        assert m.c == None
+
+        m = get_object("model", object, "", default_neurons)
+        assert m.a == 3.0
+        assert m.b == 0.0
+        assert m.c == None
+
+def test_overriden_network_defaults():
+    net = Network({Model: {"a": 3.0}})
+    with net:
+        m = Model(2.0)
+        assert m.a == 2.0
+        assert m.b == 0.0
+        assert m.c == None
+
+        m = Model(a=2.0)
+        assert m.a == 2.0
+        assert m.b == 0.0
+        assert m.c == None


### PR DESCRIPTION
One really annoying thing with this world is that e.g. LIF neurons are not defined in a uniform way between mathematical frameworks. For example, e-prop uses relative reset and doesn't integrate during the refractory period whereas EventProp does neither of these things. Not only does this mean users had to set a bunch of random flags when defining a model (see ``relative_reset`` and ``integrate_during_reset`` in the following) but they also had to change them if they switched from e.g. e-prop to EventProp.

```python
network = SequentialNetwork()
    LeakyIntegrateFire(v_thresh=0.61, tau_mem=20.0,
                                        tau_refrac=5.0,
                                       relative_reset=True,
                                       integrate_during_refrac=True,
                                       tau_refrac=5.0),
```
Now each compiler can provide a dictionary of neuron/synapse/whatever types to a dictionary of default parameters for their constructor parameters so the user can do this instead:
```python
from ml_genn.compilers.eprop_compiler import default_params

network = SequentialNetwork(default_params)
    LeakyIntegrateFire(v_thresh=0.61, tau_mem=20.0,
                                        tau_refrac=5.0,
                                       tau_refrac=5.0),
```

Internally, it is a little gnarly but the default parameters get stashed in the ``Network``/``SequentialNetwork`` object and pulled out in the ``network_default_params`` decorator which is applied to model constructor. This wraps itself around the constructor and adds these 'runtime defaults' to the specified parameters.

Fixes #59