### PR TITLE
Bugfix for strange callback behaviour with validation 

### DIFF
--- a/ml_genn/ml_genn/callbacks/spike_recorder.py
+++ b/ml_genn/ml_genn/callbacks/spike_recorder.py
@@ -30,10 +30,7 @@ class SpikeRecorder(Callback):
         # Is this SpikeRecorder the one responsible for pulling spikes?
         self._pull = False
 
-        # List of spike times and IDs
-        self._spikes = ([], [])
-
-    def set_params(self, compiled_network, **kwargs):
+    def set_params(self, data, compiled_network, **kwargs):
         # Extract compiled network
         self._batch_size = compiled_network.genn_model.batch_size
         self._compiled_network = compiled_network
@@ -60,6 +57,10 @@ class SpikeRecorder(Callback):
 
         # Create default batch mask in case on_batch_begin not called
         self._batch_mask = np.ones(self._batch_size, dtype=bool)
+
+        # Create tuple of lists to hold recorded spike times and IDs
+        data[self.key] =  ([], [])
+        self._spikes = data[self.key]
 
     def set_first(self):
         self._pull = True

--- a/ml_genn/ml_genn/callbacks/var_recorder.py
+++ b/ml_genn/ml_genn/callbacks/var_recorder.py
@@ -41,15 +41,16 @@ class VarRecorder(Callback):
         self._neuron_mask = get_neuron_filter_mask(neuron_filter,
                                                    self._pop.shape)
 
-        # Create empty list to hold recorded data
-        self._data = []
-
-    def set_params(self, compiled_network, **kwargs):
+    def set_params(self, data, compiled_network, **kwargs):
         self._batch_size = compiled_network.genn_model.batch_size
         self._compiled_network = compiled_network
 
         # Create default batch mask in case on_batch_begin not called
         self._batch_mask = np.ones(self._batch_size, dtype=bool)
+
+        # Create empty list to hold recorded data
+        data[self.key] = []
+        self._data = data[self.key]
 
     def on_timestep_end(self, timestep: int):
         # If anything should be recorded this batch

--- a/ml_genn/ml_genn/utils/callback_list.py
+++ b/ml_genn/ml_genn/utils/callback_list.py
@@ -17,18 +17,23 @@ class CallbackList:
     """Class used internally to efficiently handle lists of callback objects
     """
     def __init__(self, callbacks: Sequence[Callback], **params):
+        # Build list of callback objects
         self._callbacks = [get_object(c, Callback, "Callback",
                                       default_callbacks)
                            for c in callbacks]
 
+        # Because callback objects themselves should not be stateful,
+        # create dictionary to hold any data callbacks produce
+        self._data = {}
+
         # Loop through callbacks, build dictionary of all callbacks
-        # of each type and call set_params methods if presetn
+        # of each type and call set_params methods if present
         callback_types = defaultdict(list)
         for c in self._callbacks:
             callback_types[type(c)].append(c)
 
             if hasattr(c, "set_params"):
-                c.set_params(**params)
+                c.set_params(data=self._data, **params)
 
         # Loop through all callback types and
         # inform the first callback of each type


### PR DESCRIPTION
So this was caused by callbacks (in this case spike recorders) only getting shallow-copied into the ``CallbackList`` objects used internally to dispatch callbacks. This meant two spike recorders were adding data to the same data structure resulting in what you were seeing. The solution to this was simply to make ``CallbackList`` own the state itself  which was easy to do as it already was responsible for delivering callback data back to the ``train`` method.