### PR TITLE
Time varying inputs

### DIFF
--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -177,7 +177,8 @@ class Compiler:
 
         # If source neuron model defines a negative threshold condition
         src_pop = connection.source()
-        src_neuron_model = src_pop.neuron.get_model(src_pop, self.dt)
+        src_neuron_model = src_pop.neuron.get_model(src_pop, self.dt,
+                                                    self.batch_size)
         if "negative_threshold_condition_code" in src_neuron_model.model:
             wum = WeightUpdateModel(
                 (deepcopy(signed_static_pulse_delay_model) if het_delay
@@ -299,7 +300,7 @@ class Compiler:
 
             # Build GeNN neuron model, parameters and values
             neuron = pop.neuron
-            neuron_model = neuron.get_model(pop, self.dt)
+            neuron_model = neuron.get_model(pop, self.dt, self.batch_size)
 
             neuron_model, param_vals, var_vals, egp_vals, var_egp_vals =\
                 self.build_neuron_model(
@@ -334,7 +335,9 @@ class Compiler:
             syn = conn.synapse
             (psm, psm_param_vals, psm_var_vals, 
              psm_egp_vals, psm_var_egp_vals) =\
-                self.build_synapse_model(conn, syn.get_model(conn, self.dt),
+                self.build_synapse_model(conn,
+                                         syn.get_model(conn, self.dt,
+                                                       self.batch_size),
                                          compile_state).process()
 
             # Create custom postsynaptic model

--- a/ml_genn/ml_genn/compilers/eprop_compiler.py
+++ b/ml_genn/ml_genn/compilers/eprop_compiler.py
@@ -10,7 +10,8 @@ from ..callbacks import (BatchProgressBar, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnTimestepEnd)
 from ..losses import Loss, SparseCategoricalCrossentropy
 from ..neurons import (AdaptiveLeakyIntegrateFire, Input,
-                       LeakyIntegrate, LeakyIntegrateFire)
+                       LeakyIntegrate, LeakyIntegrateFire, 
+                       LeakyIntegrateFireInput)
 from ..optimisers import Optimiser
 from ..synapses import Delta
 from ..utils.callback_list import CallbackList
@@ -37,7 +38,10 @@ default_params = {
     LeakyIntegrate: {"scale_i": False}, 
     LeakyIntegrateFire: {"relative_reset": True, 
                          "integrate_during_refrac": True,
-                         "scale_i": False}}
+                         "scale_i": False},
+    LeakyIntegrateFireInput: {"relative_reset": True, 
+                              "integrate_during_refrac": True,
+                              "scale_i": False}}
 
 def _has_connection_to_output(pop):
     # Loop through population's outgoing connections

--- a/ml_genn/ml_genn/compilers/eprop_compiler.py
+++ b/ml_genn/ml_genn/compilers/eprop_compiler.py
@@ -9,8 +9,8 @@ from .compiled_training_network import CompiledTrainingNetwork
 from ..callbacks import (BatchProgressBar, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnTimestepEnd)
 from ..losses import Loss, SparseCategoricalCrossentropy
-from ..neurons import (AdaptiveLeakyIntegrateFire, LeakyIntegrate,
-                       LeakyIntegrateFire)
+from ..neurons import (AdaptiveLeakyIntegrateFire, Input,
+                       LeakyIntegrate, LeakyIntegrateFire)
 from ..optimisers import Optimiser
 from ..synapses import Delta
 from ..utils.callback_list import CallbackList
@@ -336,7 +336,7 @@ class EPropCompiler(Compiler):
                 compile_state.checkpoint_population_vars.append((pop, "Bias"))
 
         # Otherwise, if neuron isn't an input i.e. it's hidden
-        elif not hasattr(pop.neuron, "set_input"):
+        elif not isinstance(pop.neuron, Input):
             # Check hidden population is connected directly to output
             if not _has_connection_to_output(pop):
                 raise RuntimeError("In models trained with e-prop, all "

--- a/ml_genn/ml_genn/compilers/eprop_compiler.py
+++ b/ml_genn/ml_genn/compilers/eprop_compiler.py
@@ -274,7 +274,7 @@ class EPropCompiler(Compiler):
         if pop.neuron.readout is not None:
             # Get loss function associated with this output neuron
             loss = compile_state.losses[pop]
-            
+
             # If loss function is sparse categorical crossentropy
             if isinstance(loss, SparseCategoricalCrossentropy):
                 # Get output variable from neuron model
@@ -287,7 +287,7 @@ class EPropCompiler(Compiler):
 
                 # Finally, point output variable at new softmax'd output
                 model_copy.output_var_name = softmax_var_name
-                
+
                 # Add population to list of those needing softmax calculation
                 compile_state.softmax_populations.append(
                     (pop, output_var[0], softmax_var_name))
@@ -384,7 +384,7 @@ class EPropCompiler(Compiler):
 
         # Return model
         return model
-    
+
     def build_weight_update_model(self, conn, connect_snippet, compile_state):
         if not is_value_constant(connect_snippet.delay):
             raise NotImplementedError("E-prop compiler only "
@@ -515,7 +515,7 @@ class EPropCompiler(Compiler):
             reduction_optimiser_model = CustomUpdateModel(
                 gradient_batch_reduce_model, {}, {"ReducedGradient": 0.0},
                 {"Gradient": gradient_ref})
-            
+
             # Add GeNN custom update to model
             genn_reduction = self.add_custom_update(
                 genn_model, reduction_optimiser_model, 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -214,7 +214,7 @@ class ZeroInSynLastTimestep(Callback):
         if timestep == (self.example_timesteps - 1):
             self.genn_syn_pop.in_syn[:]= 0.0
             self.genn_syn_pop.push_in_syn_to_device()
-        
+
 # Standard EventProp weight update model
 # **NOTE** feedback is added if required
 weight_update_model = {
@@ -304,7 +304,7 @@ neuron_reset = Template(
         $$(RingSpikeTime)[ringOffset + $$(RingWriteOffset)] = $$(t);
         $write
         $$(RingWriteOffset)++;
-        
+
         // Loop around if we've reached end of circular buffer
         if ($$(RingWriteOffset) >= $max_spikes) {
             $$(RingWriteOffset) = 0;
@@ -412,17 +412,17 @@ class EventPropCompiler(Compiler):
                 if self.per_timestep_loss:
                     # Get reset vars before we add ring-buffer variables
                     reset_vars = model_copy.reset_vars
-                    
+
                     # Add variables to hold offsets for 
                     # reading and writing ring variables
                     model_copy.add_var("RingWriteOffset", "int", 0)
                     model_copy.add_var("RingReadOffset", "int", 0)
-                        
+
                     # Add EGP for softmax V ring variable
                     ring_size = self.batch_size * np.prod(pop.shape) * 2 * self.example_timesteps
                     model_copy.add_egp("RingSoftmaxV", "scalar*", 
                                        np.empty(ring_size, dtype=np.float32))
-                    
+
                     # If readout is AvgVar or SumVar
                     if isinstance(pop.neuron.readout, (AvgVar, SumVar)):
                         model_copy.prepend_sim_code(
@@ -434,7 +434,7 @@ class EventPropCompiler(Compiler):
                                 const scalar g = ($(id) == $(YTrueBack)) ? (1.0 - softmax) : -softmax;
                                 $(LambdaV) += (g / ($(TauM) * $(num_batch) * {self.dt * self.example_timesteps})) * DT; // simple Euler
                             }}
-                            
+
                             // Forward pass
                             """)
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -17,7 +17,8 @@ from ..callbacks import (BatchProgressBar, Callback, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnTimestepEnd)
 from ..connection import Connection
 from ..losses import Loss, SparseCategoricalCrossentropy
-from ..neurons import Input, LeakyIntegrate, LeakyIntegrateFire
+from ..neurons import (Input, LeakyIntegrate, LeakyIntegrateFire,
+                       LeakyIntegrateFireInput)
 from ..optimisers import Optimiser
 from ..readouts import AvgVar, AvgVarExpWeight, MaxVar, SumVar
 from ..synapses import Exponential
@@ -89,7 +90,10 @@ default_params = {
     LeakyIntegrate: {"scale_i": True}, 
     LeakyIntegrateFire: {"relative_reset": False, 
                          "integrate_during_refrac": False,
-                         "scale_i": True}}
+                         "scale_i": True},
+    LeakyIntegrateFireInput: {"relative_reset": False, 
+                              "integrate_during_refrac": False,
+                              "scale_i": True}}
 
 def _get_tau_syn(pop):
     # Loop through incoming connections

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -17,7 +17,7 @@ from ..callbacks import (BatchProgressBar, Callback, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnTimestepEnd)
 from ..connection import Connection
 from ..losses import Loss, SparseCategoricalCrossentropy
-from ..neurons import LeakyIntegrate, LeakyIntegrateFire
+from ..neurons import Input, LeakyIntegrate, LeakyIntegrateFire
 from ..optimisers import Optimiser
 from ..readouts import AvgVar, AvgVarExpWeight, MaxVar, SumVar
 from ..synapses import Exponential
@@ -577,7 +577,7 @@ class EventPropCompiler(Compiler):
                                np.empty(ring_size, dtype=np.float32))
 
             # If neuron is an input
-            if hasattr(pop.neuron, "set_input"):
+            if isinstance(pop.neuron, Input):
                 # Add reset logic to reset any state 
                 # variables from the original model
                 compile_state.add_neuron_reset_vars(pop, model.reset_vars,
@@ -769,7 +769,7 @@ class EventPropCompiler(Compiler):
 
         # If source neuron isn't an input neuron
         source_neuron = conn.source().neuron
-        if not hasattr(source_neuron, "set_input"):
+        if not isinstance(source_neuron, Input):
             # Add connection to list of feedback connections
             compile_state.feedback_connections.append(conn)
 

--- a/ml_genn/ml_genn/compilers/few_spike_compiler.py
+++ b/ml_genn/ml_genn/compilers/few_spike_compiler.py
@@ -267,7 +267,7 @@ class FewSpikeCompiler(Compiler):
                 raise NotImplementedError(
                     "FewSpike models only support output "
                     "neurons with Var readout")
-            
+
             # Add readout logic to model
             model = pop.neuron.readout.add_readout_logic(model)
 

--- a/ml_genn/ml_genn/neurons/__init__.py
+++ b/ml_genn/ml_genn/neurons/__init__.py
@@ -7,6 +7,7 @@ from .integrate_fire import IntegrateFire
 from .integrate_fire_input import IntegrateFireInput
 from .leaky_integrate import LeakyIntegrate
 from .leaky_integrate_fire import LeakyIntegrateFire
+from .leaky_integrate_fire_input import LeakyIntegrateFireInput
 from .neuron import Neuron
 from .poisson_input import PoissonInput
 from .spike_input import SpikeInput
@@ -17,5 +18,5 @@ default_neurons = get_module_classes(globals(), Neuron)
 
 __all = ["AdaptiveLeakyIntegrateFire", "BinarySpikeInput", "FewSpikeRelu",
          "FewSpikeReluInput", "Input", "IntegrateFire", "IntegrateFireInput",
-         "LeakyIntegrate", "LeakyIntegrateFire", "Neuron",
-         "PoissonInput", "SpikeInput", "default_neurons"]
+         "LeakyIntegrate", "LeakyIntegrateFire", "LeakyIntegrateFireInput", 
+         "Neuron", "PoissonInput", "SpikeInput", "default_neurons"]

--- a/ml_genn/ml_genn/neurons/__init__.py
+++ b/ml_genn/ml_genn/neurons/__init__.py
@@ -2,6 +2,7 @@ from .adaptive_leaky_integrate_fire import AdaptiveLeakyIntegrateFire
 from .binary_spike_input import BinarySpikeInput
 from .few_spike_relu import FewSpikeRelu
 from .few_spike_relu_input import FewSpikeReluInput
+from .input import Input
 from .integrate_fire import IntegrateFire
 from .integrate_fire_input import IntegrateFireInput
 from .leaky_integrate import LeakyIntegrate
@@ -15,6 +16,6 @@ from ..utils.module import get_module_classes
 default_neurons = get_module_classes(globals(), Neuron)
 
 __all = ["AdaptiveLeakyIntegrateFire", "BinarySpikeInput", "FewSpikeRelu",
-         "FewSpikeReluInput", "IntegrateFire", "IntegrateFireInput",
+         "FewSpikeReluInput", "Input", "IntegrateFire", "IntegrateFireInput",
          "LeakyIntegrate", "LeakyIntegrateFire", "Neuron",
          "PoissonInput", "SpikeInput", "default_neurons"]

--- a/ml_genn/ml_genn/neurons/adaptive_leaky_integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/adaptive_leaky_integrate_fire.py
@@ -37,7 +37,7 @@ class AdaptiveLeakyIntegrateFire(Neuron):
         self.relative_reset = relative_reset
         self.integrate_during_refrac = integrate_during_refrac
 
-    def get_model(self, population, dt):
+    def get_model(self, population, dt, batch_size):
         # Build basic model
         genn_model = {
             "var_name_types": [("V", "scalar"), ("A", "scalar")],

--- a/ml_genn/ml_genn/neurons/binary_spike_input.py
+++ b/ml_genn/ml_genn/neurons/binary_spike_input.py
@@ -10,17 +10,15 @@ class BinarySpikeInput(Neuron, InputBase):
 
         self.signed_spikes = signed_spikes
 
-    def get_model(self, population, dt):
+    def get_model(self, population, batch_size):
         genn_model = {
-            "var_name_types": [("Input", "scalar",
-                                VarAccess_READ_ONLY_DUPLICATE)],
             "sim_code":
                 """
                 const bool spike = $(Input) != 0.0;
                 """,
             "threshold_condition_code":
                 """
-                $(Input) > 0.0 && spike
+                $(Isyn) > 0.0 && spike
                 """,
             "is_auto_refractory_required": False}
 
@@ -28,7 +26,9 @@ class BinarySpikeInput(Neuron, InputBase):
         if self.signed_spikes:
             genn_model["negative_threshold_condition_code"] =\
                 """
-                $(Input_pre) < 0.0 && spike
+                $(Input) < 0.0 && spike
                 """
 
-        return NeuronModel(genn_model, None, {}, {"Input": 0.0})
+        neuron_model = NeuronModel(genn_model, None, {}, {})
+        self.add_input_logic(neuron_model, batch_size, population.shape)
+        return neuron_model

--- a/ml_genn/ml_genn/neurons/binary_spike_input.py
+++ b/ml_genn/ml_genn/neurons/binary_spike_input.py
@@ -1,5 +1,5 @@
 from pygenn.genn_wrapper.Models import VarAccess_READ_ONLY_DUPLICATE
-from .input_base import InputBase
+from .input import InputBase
 from .neuron import Neuron
 from ..utils.model import NeuronModel
 

--- a/ml_genn/ml_genn/neurons/binary_spike_input.py
+++ b/ml_genn/ml_genn/neurons/binary_spike_input.py
@@ -3,6 +3,10 @@ from .input import InputBase
 from .neuron import Neuron
 from ..utils.model import NeuronModel
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .. import Population
 
 class BinarySpikeInput(Neuron, InputBase):
     def __init__(self, signed_spikes=False, input_frames=1,
@@ -16,7 +20,7 @@ class BinarySpikeInput(Neuron, InputBase):
             raise NotImplementedError("Signed spike input cannot currently "
                                       "be used with time-varying inputs ")
 
-    def get_model(self, population, batch_size):
+    def get_model(self, population: "Population", dt: float, batch_size: int):
         genn_model = {
             "sim_code":
                 """
@@ -35,6 +39,6 @@ class BinarySpikeInput(Neuron, InputBase):
                 $(Input) < 0.0 && spike
                 """
 
-        neuron_model = NeuronModel(genn_model, None, {}, {})
-        self.add_input_logic(neuron_model, batch_size, population.shape)
-        return neuron_model
+        # Add standard input logic to model and return
+        return self.create_input_model(NeuronModel(genn_model, None, {}, {}),
+                                       batch_size, population.shape)

--- a/ml_genn/ml_genn/neurons/binary_spike_input.py
+++ b/ml_genn/ml_genn/neurons/binary_spike_input.py
@@ -36,9 +36,9 @@ class BinarySpikeInput(Neuron, InputBase):
         if self.signed_spikes:
             genn_model["negative_threshold_condition_code"] =\
                 """
-                $(Input) < 0.0 && spike
+                $(Input_pre) < 0.0 && spike
                 """
 
         # Add standard input logic to model and return
         return self.create_input_model(NeuronModel(genn_model, None, {}, {}),
-                                       batch_size, population.shape)
+                                       batch_size, population.shape, replace_input="$(Input)")

--- a/ml_genn/ml_genn/neurons/binary_spike_input.py
+++ b/ml_genn/ml_genn/neurons/binary_spike_input.py
@@ -5,10 +5,16 @@ from ..utils.model import NeuronModel
 
 
 class BinarySpikeInput(Neuron, InputBase):
-    def __init__(self, signed_spikes=False):
-        super(BinarySpikeInput, self).__init__()
+    def __init__(self, signed_spikes=False, input_frames=1,
+                 input_frame_time=1):
+        super(BinarySpikeInput, self).__init__(
+            egp_name="Input", input_frames=input_frames,
+            input_frame_time=input_frame_time)
 
         self.signed_spikes = signed_spikes
+        if self.signed_spikes and input_frames > 1:
+            throw NotImplementedError("Signed spike input cannot currently "
+                                      "be used with time-varying inputs ")
 
     def get_model(self, population, batch_size):
         genn_model = {
@@ -18,7 +24,7 @@ class BinarySpikeInput(Neuron, InputBase):
                 """,
             "threshold_condition_code":
                 """
-                $(Isyn) > 0.0 && spike
+                $(Input) > 0.0 && spike
                 """,
             "is_auto_refractory_required": False}
 

--- a/ml_genn/ml_genn/neurons/binary_spike_input.py
+++ b/ml_genn/ml_genn/neurons/binary_spike_input.py
@@ -13,7 +13,7 @@ class BinarySpikeInput(Neuron, InputBase):
 
         self.signed_spikes = signed_spikes
         if self.signed_spikes and input_frames > 1:
-            throw NotImplementedError("Signed spike input cannot currently "
+            raise NotImplementedError("Signed spike input cannot currently "
                                       "be used with time-varying inputs ")
 
     def get_model(self, population, batch_size):

--- a/ml_genn/ml_genn/neurons/few_spike_relu.py
+++ b/ml_genn/ml_genn/neurons/few_spike_relu.py
@@ -105,7 +105,7 @@ class FewSpikeRelu(Neuron):
         self.k = k
         self.alpha = alpha
 
-    def get_model(self, population, dt):
+    def get_model(self, population, dt, batch_size):
         # Loop through incoming connections
         source_alpha = None
         source_signed = None

--- a/ml_genn/ml_genn/neurons/few_spike_relu_input.py
+++ b/ml_genn/ml_genn/neurons/few_spike_relu_input.py
@@ -79,3 +79,5 @@ class FewSpikeReluInput(Neuron, InputBase):
         model = genn_model_signed if self.signed_input else genn_model
         neuron_model = NeuronModel(model, None, {"K": self.k, "Scale": scale},
                                    {"V": 0.0})
+        self.add_input_logic(neuron_model, batch_size, population.shape)
+        return neuron_model

--- a/ml_genn/ml_genn/neurons/few_spike_relu_input.py
+++ b/ml_genn/ml_genn/neurons/few_spike_relu_input.py
@@ -1,4 +1,4 @@
-from .input_base import InputBase
+from .input import InputBase
 from .neuron import Neuron
 from ..utils.model import NeuronModel
 from ..utils.snippet import ConstantValueDescriptor

--- a/ml_genn/ml_genn/neurons/few_spike_relu_input.py
+++ b/ml_genn/ml_genn/neurons/few_spike_relu_input.py
@@ -77,7 +77,7 @@ class FewSpikeReluInput(Neuron, InputBase):
             scale = self.alpha * 2**(-self.k)
 
         model = genn_model_signed if self.signed_input else genn_model
-        neuron_model = NeuronModel(model, None, {"K": self.k, "Scale": scale},
-                                   {"V": 0.0})
-        self.add_input_logic(neuron_model, batch_size, population.shape)
-        return neuron_model
+        return self.create_input_model(
+            NeuronModel(model, None, {"K": self.k, "Scale": scale}, {"V": 0.0}),
+            batch_size, population.shape)
+

--- a/ml_genn/ml_genn/neurons/few_spike_relu_input.py
+++ b/ml_genn/ml_genn/neurons/few_spike_relu_input.py
@@ -76,8 +76,9 @@ class FewSpikeReluInput(Neuron, InputBase):
         else:
             scale = self.alpha * 2**(-self.k)
 
+        # Return appropriate neuron model
+        # **NOTE** because this model doesn't support time-varying input
+        # and input is read into an existing state variable, no need to use create_input_model
         model = genn_model_signed if self.signed_input else genn_model
-        return self.create_input_model(
-            NeuronModel(model, None, {"K": self.k, "Scale": scale}, {"V": 0.0}),
-            batch_size, population.shape)
+        return NeuronModel(model, None, {"K": self.k, "Scale": scale}, {"V": 0.0})
 

--- a/ml_genn/ml_genn/neurons/few_spike_relu_input.py
+++ b/ml_genn/ml_genn/neurons/few_spike_relu_input.py
@@ -69,7 +69,7 @@ class FewSpikeReluInput(Neuron, InputBase):
         self.alpha = alpha
         self.signed_input = signed_input
 
-    def get_model(self, population, dt):
+    def get_model(self, population, dt, batch_size):
         # Calculate scale
         if self.signed_input:
             scale = self.alpha * 2**(-self.k // 2)
@@ -77,5 +77,5 @@ class FewSpikeReluInput(Neuron, InputBase):
             scale = self.alpha * 2**(-self.k)
 
         model = genn_model_signed if self.signed_input else genn_model
-        return NeuronModel(model, None, {"K": self.k, "Scale": scale},
-                           {"V": 0.0})
+        neuron_model = NeuronModel(model, None, {"K": self.k, "Scale": scale},
+                                   {"V": 0.0})

--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -43,8 +43,9 @@ class InputBase(Input):
         # If input isn't time-varying
         if self.input_frames == 1:
             # Add read-only input variable
-            nm_copy.add_var(self.var_name, "scalar", 0.0,
-                            VarAccess_READ_ONLY_DUPLICATE)
+            if not nm_copy.has_var(self.var_name):
+                nm_copy.add_var(self.var_name, "scalar", 0.0,
+                                VarAccess_READ_ONLY_DUPLICATE)
 
             # Prepend sim code with code to initialize
             # local variable to input + synaptic input
@@ -52,6 +53,7 @@ class InputBase(Input):
                 f"const scalar input = $({self.var_name}) + $(Isyn);")
         else:
             # If batch size is 1
+            assert not nm_copy.has_var(self.egp_name)
             flat_shape = np.prod(shape)
             if batch_size == 1:
                 # Add EGP

--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -88,9 +88,9 @@ class InputBase(Input):
             if batch_size == 1:
                 # Check input shape either has no batch
                 # dimension or it has a length of 1
-                if (len(input_time_batch_dims) != 0
-                    and (len(input_time_batch_dims) != 1
-                         or input_time_batch_dims[0] != 1):
+                if (len(input_batch_time_dims) != 0
+                    and (len(input_batch_time_dims) != 1
+                         or input_batch_time_dims[0] != 1)):
                     raise RuntimeError(f"Input shape {input.shape} does "
                                        f"not match batch size {batch_size}")
 
@@ -100,8 +100,8 @@ class InputBase(Input):
             else:
                 # Check input shape has batch dimension
                 # and this is less than or equal to batch size
-                if (len(input_time_batch_dims) != 1
-                    or input_time_batch_dims[0] > batch_size):
+                if (len(input_batch_time_dims) != 1
+                    or input_batch_time_dims[0] > batch_size):
                     raise RuntimeError(f"Input shape {input.shape} does "
                                        f"not match batch size {batch_size}")
 
@@ -134,9 +134,9 @@ class InputBase(Input):
             if batch_size == 1:
                 # Check input shape either has no batch
                 # dimension or it has a length of 1
-                if (len(input_time_batch_dims) != 1
-                    and (len(input_time_batch_dims) != 2
-                         or input_time_batch_dims[0] != 1):
+                if (len(input_batch_time_dims) != 1
+                    and (len(input_batch_time_dims) != 2
+                         or input_batch_time_dims[0] != 1)):
                     raise RuntimeError(f"Input shape {input.shape} does "
                                        f"not match batch size {batch_size}")
 
@@ -146,8 +146,8 @@ class InputBase(Input):
             else:
                 # Check input shape has batch dimension
                 # and this is less than or equal to batch size
-                if (len(input_time_batch_dims) != 2
-                    or input_time_batch_dims[0] > batch_size):
+                if (len(input_batch_time_dims) != 2
+                    or input_batch_time_dims[0] > batch_size):
                     raise RuntimeError(f"Input shape {input.shape} does "
                                        f"not match batch size {batch_size}")
 

--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -58,27 +58,27 @@ class InputBase(Input):
             if batch_size == 1:
                 # Add EGP
                 nm_copy.add_egp(self.egp_name, "scalar*",
-                                np.empty(self.input_frames,) + shape)
+                                np.empty((self.input_frames,) + shape))
 
                 # Prepend sim code with code to initialize
                 # local variable tosigned_spikes correct EGP entry + synaptic input
                 nm_copy.prepend_sim_code(
                     f"""
-                    const int timestep = min((int)round($(t) / ({self.input_frame_time} * DT)), {self.input_frames - 1});
-                    const scalar input = $({self.egp_name})[($(t) * {flat_shape}) + $(id)] + $(Isyn);")
+                    const int timestep = min((int)($(t) / ({self.input_frame_time} * DT)), {self.input_frames - 1});
+                    const scalar input = $({self.egp_name})[($(t) * {flat_shape}) + $(id)] + $(Isyn);
                     """)
             else:
                 # Add EGP
                 nm_copy.add_egp(
                     self.egp_name, "scalar*",
-                    np.empty(self.input_frames, batch_size) + shape)
+                    np.empty((self.input_frames, batch_size) + shape))
 
                 # Prepend sim code with code to initialize
                 # local variable to correct EGP entry + synaptic input
                 nm_copy.prepend_sim_code(
                     f"""
-                    const int timestep = min((int)round($(t) / ({self.input_frame_time} * DT)), {self.input_frames - 1});
-                    const scalar input = $({self.egp_name})[($(batch) * {flat_shape * self.input_frames}) + (timestep * {flat_shape}) + $(id)] + $(Isyn);")
+                    const int timestep = min((int)($(t) / ({self.input_frame_time} * DT)), {self.input_frames - 1});
+                    const scalar input = $({self.egp_name})[($(batch) * {flat_shape * self.input_frames}) + (timestep * {flat_shape}) + $(id)] + $(Isyn);
                     """)
         return nm_copy
 
@@ -172,13 +172,13 @@ class InputBase(Input):
                 # If we have a full batch
                 input_batch_size = batched_input.shape[0]
                 if input_batch_size == batch_size:
-                    egp_view[:] = batched_input
+                    egp_view[:] = batched_input.flatten()
 
                 # Otherwise, pad up to full batch
                 else:
                     egp_view[:] = np.pad(batched_input,
                                          ((0, batch_size - input_batch_size),
-                                          (0, 0)))
+                                          (0, 0))).flatten()
 
             # Push variable to device
             genn_pop.push_extra_global_param_to_device(self.egp_name)

--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -1,7 +1,17 @@
 import numpy as np
 
+from abc import ABC
 
-class InputBase:
+from abc import abstractmethod
+
+
+class Input:
+    @abstractmethod
+    def set_input(self, compiled_net, pop, input):
+        pass
+
+
+class InputBase(Input):
     def __init__(self, var_name="Input", **kwargs):
         super(InputBase, self).__init__(**kwargs)
 

--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -11,10 +11,9 @@ class Input:
     def set_input(self, compiled_net, pop, input):
         pass
 
-
 class InputBase(Input):
     def __init__(self, var_name="Input", egp_name=None,
-                 input_timesteps=1, input_dt=1,
+                 input_timesteps=1, input_step=1,
                  **kwargs):
         super(InputBase, self).__init__(**kwargs)
 
@@ -26,12 +25,9 @@ class InputBase(Input):
         self.var_name = var_name
         self.egp_name = egp_name
         self.input_timesteps = input_timesteps
-        self.input_dt = input_dt
+        self.input_step = input_step
 
     def add_input_logic(self, neuron_model, batch_size: int, shape):
-        # Replace input references in sim code with local variable reference
-        neuron_model.replace_input("input")
-
         # If input isn't time-varying
         if self.input_timesteps == 1:
             # Add read-only input variable
@@ -51,10 +47,10 @@ class InputBase(Input):
                                      np.empty(self.input_timesteps,) + shape)
 
                 # Prepend sim code with code to initialize
-                # local variable to correct EGP entry + synaptic input
+                # local variable tosigned_spikes correct EGP entry + synaptic input
                 neuron_model.prepend_sim_code(
                     f"""
-                    const int timestep = (int)($(t) / DT);
+                    const int timestep = min((int)round($(t) / ({self.input_step} * DT)), {self.input_timesteps - 1});
                     const scalar input = $({self.egp_name})[($(t) * {flat_shape}) + $(id)] + $(Isyn);")
                     """)
             else:
@@ -67,8 +63,8 @@ class InputBase(Input):
                 # local variable to correct EGP entry + synaptic input
                 neuron_model.prepend_sim_code(
                     f"""
-                    const int timestep = (int)($(t) / DT);
-                    const scalar input = $({self.egp_name})[($(t) * {flat_shape}) + $(id)] + $(Isyn);")
+                    const int timestep = min((int)round($(t) / ({self.input_step} * DT)), {self.input_timesteps - 1});
+                    const scalar input = $({self.egp_name})[($(batch) * {flat_shape * self.input_timesteps}) + (timestep * {flat_shape}) + $(id)] + $(Isyn);")
                     """)
 
 
@@ -76,38 +72,99 @@ class InputBase(Input):
         # Ensure input is something convertable to a numpy array
         input = np.asarray(input)
 
-        # If batch size is 1
-        if batch_size == 1:
-            # Give error if shapes don't match
-            if input.shape != shape and (input.shape[0] != 1
-                                         or input.shape[1:] != shape):
-                raise RuntimeError(f"Input shape {input.shape} does not match "
-                                   f"population shape {shape}")
+        # Split input shape into the bit that should match population
+        # shape and the bit that should match time and batch
+        input_shape_dims = input.shape[-len(shape):]
+        input_batch_time_dims = input.shape[:-len(shape)]
 
-            # Flatten input and copy into view
-            genn_pop.vars[self.var_name].view[:] = input.flatten()
+        # Check last dimensions of input shape match population shape
+        if input_shape_dims != shape:
+            raise RuntimeError(f"Input shape {input.shape} does not match "
+                               f"population shape {shape}")
+
+        # If input ivar_namesn't time-varying
+        if self.input_timesteps == 1:
+            # If batch size is 1
+            if batch_size == 1:
+                # Check input shape either has no batch
+                # dimension or it has a length of 1
+                if (len(input_time_batch_dims) != 0
+                    and (len(input_time_batch_dims) != 1
+                         or input_time_batch_dims[0] != 1):
+                    raise RuntimeError(f"Input shape {input.shape} does "
+                                       f"not match batch size {batch_size}")
+
+                # Flatten input and copy into view
+                genn_pop.vars[self.var_name].view[:] = input.flatten()
+            # Otherwise
+            else:
+                # Check input shape has batch dimension
+                # and this is less than or equal to batch size
+                if (len(input_time_batch_dims) != 1
+                    or input_time_batch_dims[0] > batch_size):
+                    raise RuntimeError(f"Input shape {input.shape} does "
+                                       f"not match batch size {batch_size}")
+
+                # Reshape input into batches of flattened data
+                batched_input = np.reshape(input, (-1, np.prod(shape)))
+
+                # If we have a full batch
+                input_batch_size = batched_input.shape[0]
+                if input_batch_size == batch_size:
+                    genn_pop.vars[self.var_name].view[:] = batched_input
+
+                # Otherwise, pad up to full batch
+                else:
+                    genn_pop.vars[self.var_name].view[:] = np.pad(
+                        batched_input,
+                        ((0, batch_size - input_batch_size), (0, 0)))
+
+            # Push variable to device
+            genn_pop.push_var_to_device(self.var_name)
         # Otherwise
         else:
-            # If non-batch dimensions of input don't match shape
-            if input.shape[1:] != shape:
-                raise RuntimeError(f"Input shape {input.shape[1:]} does not "
-                                   f"match population shape {shape}")
+            # Check time dimension matches
+            if (len(input_batch_time_dims) == 0
+                or input_batch_time_dims[-1] != self.input_timesteps):
+                raise RuntimeError(f"Input shape {input.shape} does not "
+                                   f"match timesteps {self.input_timesteps}")
 
-            # Reshape input into batches of flattened data
-            batched_input = np.reshape(input, (-1, np.prod(shape)))
+            # If batch size is 1
+            egp_view = genn_pop.extra_global_params[self.egp_name].view
+            if batch_size == 1:
+                # Check input shape either has no batch
+                # dimension or it has a length of 1
+                if (len(input_time_batch_dims) != 1
+                    and (len(input_time_batch_dims) != 2
+                         or input_time_batch_dims[0] != 1):
+                    raise RuntimeError(f"Input shape {input.shape} does "
+                                       f"not match batch size {batch_size}")
 
-            # If we have a full batch
-            input_batch_size = batched_input.shape[0]
-            if input_batch_size == batch_size:
-                genn_pop.vars[self.var_name].view[:] = batched_input
-            # Otherwise, pad up to full batch
-            elif input_batch_size < batch_size:
-                genn_pop.vars[self.var_name].view[:] = np.pad(
-                    batched_input,
-                    ((0, batch_size - input_batch_size), (0, 0)))
+                # Flatten input and copy into view
+                egp_view[:] = input.flatten()
+            # Otherwise
             else:
-                raise RuntimeError(f"Input batch size {input_batch_size} does "
-                                   f"not match batch size {batch_size}")
+                # Check input shape has batch dimension
+                # and this is less than or equal to batch size
+                if (len(input_time_batch_dims) != 2
+                    or input_time_batch_dims[0] > batch_size):
+                    raise RuntimeError(f"Input shape {input.shape} does "
+                                       f"not match batch size {batch_size}")
 
-        # Push variable to device
-        genn_pop.push_var_to_device(self.var_name)
+                # Reshape input into batches of flattened data
+                input_size = self.input_timesteps * np.prod(shape)
+                batched_input = np.reshape(input, (-1, input_size))
+
+                # If we have a full batch
+                input_batch_size = batched_input.shape[0]
+                if input_batch_size == batch_size:
+                    egp_view[:] = batched_input
+
+                # Otherwise, pad up to full batch
+                else:
+                    egp_view[:] = np.pad(batched_input,
+                                         ((0, batch_size - input_batch_size),
+                                          (0, 0)))
+
+            # Push variable to device
+            genn_pop.push_extra_global_param_to_device(self.egp_name)

--- a/ml_genn/ml_genn/neurons/integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire.py
@@ -36,5 +36,5 @@ class IntegrateFire(Neuron):
         self.v_reset = v_reset
         self.v = v
 
-    def get_model(self, population, dt):
+    def get_model(self, population, dt, batch_size):
         return NeuronModel.from_val_descriptors(genn_model, "V", self, dt)

--- a/ml_genn/ml_genn/neurons/integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire.py
@@ -29,8 +29,8 @@ class IntegrateFire(Neuron):
 
     def __init__(self, v_thresh: InitValue = 1.0, v_reset: InitValue = 0.0,
                  v: InitValue = 0.0, softmax: Optional[bool] = None,
-                 readout=None):
-        super(IntegrateFire, self).__init__(softmax, readout)
+                 readout=None, **kwargs):
+        super(IntegrateFire, self).__init__(softmax, readout, **kwargs)
 
         self.v_thresh = v_thresh
         self.v_reset = v_reset

--- a/ml_genn/ml_genn/neurons/integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire_input.py
@@ -1,5 +1,6 @@
 from .input import InputBase
 from .integrate_fire import IntegrateFire
+from ..utils.value import InitValue
 
 
 class IntegrateFireInput(IntegrateFire, InputBase):

--- a/ml_genn/ml_genn/neurons/integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire_input.py
@@ -16,8 +16,6 @@ class IntegrateFireInput(IntegrateFire, InputBase):
         nm = super(IntegrateFireInput, self).get_model(population, dt,
                                                        batch_size)
 
-        # Replace standard Isyn input with reference
-        # to local variable, add input logic and return
-        nm.replace_input("input")
-        self.add_input_logic(nm, batch_size, population.shape)
-        return nm
+        # Add input logic and replace isyn with input
+        return self.create_input_model(nm, batch_size, population.shape,
+                                       replace_isyn=True)

--- a/ml_genn/ml_genn/neurons/integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire_input.py
@@ -18,4 +18,4 @@ class IntegrateFireInput(IntegrateFire, InputBase):
 
         # Add input logic and replace isyn with input
         return self.create_input_model(nm, batch_size, population.shape,
-                                       replace_isyn=True)
+                                       replace_input="$(Isyn)")

--- a/ml_genn/ml_genn/neurons/integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire_input.py
@@ -4,10 +4,10 @@ from .integrate_fire import IntegrateFire
 
 class IntegrateFireInput(IntegrateFire, InputBase):
     def __init__(self, v_thresh: InitValue = 1.0, v_reset: InitValue = 0.0,
-                 v: InitValue = 0.0, input_timesteps=1, input_step=1):
+                 v: InitValue = 0.0, input_frames=1, input_frame_time=1):
         super(IntegrateFireInput, self).__init__(
             v_thresh=v_thresh, v_reset=v_reset, v=v, egp_name="Input",
-            input_timesteps=input_timesteps, input_step=input_step)
+            input_frames=input_frames, input_frame_time=input_frame_time)
 
 
     def get_model(self, population, dt, batch_size):

--- a/ml_genn/ml_genn/neurons/integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire_input.py
@@ -1,41 +1,22 @@
-from pygenn.genn_wrapper.Models import VarAccess_READ_ONLY_DUPLICATE
 from .input import InputBase
-from .neuron import Neuron
-from ..utils.model import NeuronModel
-from ..utils.value import InitValue, ValueDescriptor
-
-genn_model = {
-    "var_name_types": [("Input", "scalar", VarAccess_READ_ONLY_DUPLICATE),
-                       ("V", "scalar")],
-    "param_name_types": [("Vthresh", "scalar"), ("Vreset", "scalar")],
-    "sim_code":
-        """
-        $(V) += $(Input);
-        """,
-    "threshold_condition_code":
-        """
-        $(V) >= $(Vthresh)
-        """,
-    "reset_code":
-        """
-        $(V) = $(Vreset);
-        """,
-    "is_auto_refractory_required": False}
+from .integrate_fire import IntegrateFire
 
 
-class IntegrateFireInput(Neuron, InputBase):
-    v_thresh = ValueDescriptor("Vthresh")
-    v_reset = ValueDescriptor("Vreset")
-    v = ValueDescriptor("V")
-
+class IntegrateFireInput(IntegrateFire, InputBase):
     def __init__(self, v_thresh: InitValue = 1.0, v_reset: InitValue = 0.0,
-                 v: InitValue = 0.0):
-        super(IntegrateFireInput, self).__init__()
+                 v: InitValue = 0.0, input_timesteps=1, input_step=1):
+        super(IntegrateFireInput, self).__init__(
+            v_thresh=v_thresh, v_reset=v_reset, v=v, egp_name="Input",
+            input_timesteps=input_timesteps, input_step=input_step)
 
-        self.v_thresh = v_thresh
-        self.v_reset = v_reset
-        self.v = v
 
-    def get_model(self, population, dt):
-        return NeuronModel.from_val_descriptors(genn_model, None, self, dt,
-                                                var_vals={"Input": 0.0})
+    def get_model(self, population, dt, batch_size):
+        # Get standard integrate-and-fire model
+        nm = super(IntegrateFireInput, self).get_model(population, dt,
+                                                       batch_size)
+
+        # Replace standard Isyn input with reference
+        # to local variable, add input logic and return
+        nm.replace_input("input")
+        self.add_input_logic(nm, batch_size: population.shape)
+        return nm

--- a/ml_genn/ml_genn/neurons/integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire_input.py
@@ -1,5 +1,5 @@
 from pygenn.genn_wrapper.Models import VarAccess_READ_ONLY_DUPLICATE
-from .input_base import InputBase
+from .input import InputBase
 from .neuron import Neuron
 from ..utils.model import NeuronModel
 from ..utils.value import InitValue, ValueDescriptor

--- a/ml_genn/ml_genn/neurons/integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/integrate_fire_input.py
@@ -18,5 +18,5 @@ class IntegrateFireInput(IntegrateFire, InputBase):
         # Replace standard Isyn input with reference
         # to local variable, add input logic and return
         nm.replace_input("input")
-        self.add_input_logic(nm, batch_size: population.shape)
+        self.add_input_logic(nm, batch_size, population.shape)
         return nm

--- a/ml_genn/ml_genn/neurons/leaky_integrate.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate.py
@@ -23,7 +23,7 @@ class LeakyIntegrate(Neuron):
         self.tau_mem = tau_mem
         self.scale_i = scale_i
 
-    def get_model(self, population, dt):
+    def get_model(self, population, dt, batch_size):
         genn_model = {
             "var_name_types": [("V", "scalar")],
             "param_name_types": [("Alpha", "scalar"), ("Bias", "scalar")],

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
@@ -31,7 +31,7 @@ class LeakyIntegrateFire(Neuron):
         self.integrate_during_refrac = integrate_during_refrac
         self.scale_i = scale_i
 
-    def get_model(self, population, dt):
+    def get_model(self, population, dt, batch_size):
         # Build basic model
         genn_model = {
             "var_name_types": [("V", "scalar")],

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
@@ -19,8 +19,8 @@ class LeakyIntegrateFire(Neuron):
                  v: InitValue = 0.0, tau_mem: InitValue = 20.0,
                  tau_refrac: InitValue = None, relative_reset: bool = True,
                  integrate_during_refrac: bool = True, scale_i: bool = False,
-                 softmax: Optional[bool] = None, readout=None):
-        super(LeakyIntegrateFire, self).__init__(softmax, readout)
+                 softmax: Optional[bool] = None, readout=None,  **kwargs):
+        super(LeakyIntegrateFire, self).__init__(softmax, readout, **kwargs)
 
         self.v_thresh = v_thresh
         self.v_reset = v_reset

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
@@ -22,8 +22,6 @@ class LeakyIntegrateFireInput(LeakyIntegrateFire, InputBase):
         nm = super(LeakyIntegrateFireInput, self).get_model(population, dt,
                                                             batch_size)
 
-        # Replace standard Isyn input with reference
-        # to local variable, add input logic and return
-        nm.replace_input("input")
-        self.add_input_logic(nm, batch_size, population.shape)
-        return nm
+        # Add input logic and replace isyn with input
+        return self.create_input_model(nm, batch_size, population.shape,
+                                       replace_isyn=True)

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
@@ -24,4 +24,4 @@ class LeakyIntegrateFireInput(LeakyIntegrateFire, InputBase):
 
         # Add input logic and replace isyn with input
         return self.create_input_model(nm, batch_size, population.shape,
-                                       replace_isyn=True)
+                                       replace_input="$(Isyn)")

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
@@ -1,0 +1,28 @@
+from .input import InputBase
+from .leaky_integrate_fire import LeakyIntegrateFire
+
+
+class LeakyIntegrateFireInput(LeakyIntegrateFire, InputBase):
+    def __init__(self, v_thresh: InitValue = 1.0, v_reset: InitValue = 0.0,
+                 v: InitValue = 0.0, tau_mem: InitValue = 20.0,
+                 tau_refrac: InitValue = None, relative_reset: bool = True,
+                 integrate_during_refrac: bool = True, scale_i: bool = False,
+                 softmax: Optional[bool] = None, input_frames=1, input_frame_time=1):
+        super(LeakyIntegrateFireInput, self).__init__(
+            v_thresh=v_thresh, v_reset=v_reset, v=v, tau_mem=tau_mem, 
+            tau_refrac=tau_refrac, relative_reset=relative_reset, 
+            integrate_during_refrac=integrate_during_refrac, scale_i=scale_i,
+            softmax=softmax, egp_name="Input", input_frames=input_frames, 
+            input_frame_time=input_frame_time)
+
+
+    def get_model(self, population, dt, batch_size):
+        # Get standard integrate-and-fire model
+        nm = super(LeakyIntegrateFireInput, self).get_model(population, dt,
+                                                            batch_size)
+
+        # Replace standard Isyn input with reference
+        # to local variable, add input logic and return
+        nm.replace_input("input")
+        self.add_input_logic(nm, batch_size, population.shape)
+        return nm

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire_input.py
@@ -1,5 +1,6 @@
 from .input import InputBase
 from .leaky_integrate_fire import LeakyIntegrateFire
+from ..utils.value import InitValue
 
 
 class LeakyIntegrateFireInput(LeakyIntegrateFire, InputBase):
@@ -7,12 +8,12 @@ class LeakyIntegrateFireInput(LeakyIntegrateFire, InputBase):
                  v: InitValue = 0.0, tau_mem: InitValue = 20.0,
                  tau_refrac: InitValue = None, relative_reset: bool = True,
                  integrate_during_refrac: bool = True, scale_i: bool = False,
-                 softmax: Optional[bool] = None, input_frames=1, input_frame_time=1):
+                 input_frames=1, input_frame_time=1):
         super(LeakyIntegrateFireInput, self).__init__(
             v_thresh=v_thresh, v_reset=v_reset, v=v, tau_mem=tau_mem, 
             tau_refrac=tau_refrac, relative_reset=relative_reset, 
             integrate_during_refrac=integrate_during_refrac, scale_i=scale_i,
-            softmax=softmax, egp_name="Input", input_frames=input_frames, 
+            egp_name="Input", input_frames=input_frames,
             input_frame_time=input_frame_time)
 
 

--- a/ml_genn/ml_genn/neurons/neuron.py
+++ b/ml_genn/ml_genn/neurons/neuron.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 class Neuron(ABC):
     """Base class for all neuron models
-    
+
     Attributes:
         readout: Type of readout to attach to this neuron's output variable
     """
@@ -25,7 +25,7 @@ class Neuron(ABC):
                  readout: Optional[Readout] = None, **kwargs):
         super(Neuron, self).__init__(**kwargs)
         self.readout = readout
-        
+
         # Give warning if softmax argument is used
         if softmax is not None:
             warn("The softmax argument is no longer "
@@ -34,7 +34,7 @@ class Neuron(ABC):
     @abstractmethod
     def get_model(self, population: Population, dt: float) -> NeuronModel:
         """Gets model implementing this neuron
-        
+
         Args:
             population: Population this neuron is to be attached to
             dt : Timestep of simulation (in ms)
@@ -47,7 +47,7 @@ class Neuron(ABC):
     def get_readout(self, genn_pop, batch_size: int, shape):
         """Use readout object associated with neuon to
         read output from PyGeNN neuron group
-        
+
         Args:
             genn_pop: PyGeNN neuron group
             batch_size: Batch size of compiled model
@@ -61,18 +61,18 @@ class Neuron(ABC):
                                "without readout strategy")
         else:
             return self.readout.get_readout(genn_pop, batch_size, shape)
-    
+
     @property
     def readout(self):
         """Optional object which can be used to
         provide a readout from neuron
-        
+
         Can be specified as either a Readout object or, 
         for built in readout models whose constructors 
         require no arguments, a string e.g. "spike_count"
         """
         return self._readout
-    
+
     @readout.setter
     def readout(self, r):
         self._readout = get_object(r, Readout, "Readout",

--- a/ml_genn/ml_genn/neurons/neuron.py
+++ b/ml_genn/ml_genn/neurons/neuron.py
@@ -32,7 +32,8 @@ class Neuron(ABC):
                  "required and will be removed", DeprecationWarning)
 
     @abstractmethod
-    def get_model(self, population: Population, dt: float) -> NeuronModel:
+    def get_model(self, population: Population,
+                  dt: float, batch_size: int) -> NeuronModel:
         """Gets model implementing this neuron
 
         Args:

--- a/ml_genn/ml_genn/neurons/poisson_input.py
+++ b/ml_genn/ml_genn/neurons/poisson_input.py
@@ -1,5 +1,5 @@
 from pygenn.genn_wrapper.Models import VarAccess_READ_ONLY_DUPLICATE
-from .input_base import InputBase
+from .input import InputBase
 from .neuron import Neuron
 from ..utils.model import NeuronModel
 

--- a/ml_genn/ml_genn/neurons/poisson_input.py
+++ b/ml_genn/ml_genn/neurons/poisson_input.py
@@ -3,17 +3,25 @@ from .input import InputBase
 from .neuron import Neuron
 from ..utils.model import NeuronModel
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .. import Population
 
 class PoissonInput(Neuron, InputBase):
-    def __init__(self, signed_spikes=False):
-        super(PoissonInput, self).__init__()
+    def __init__(self, signed_spikes=False, input_frames=1, 
+                 input_frame_time=1):
+        super(PoissonInput, self).__init__(egp_name="Input", 
+                                           input_frames=input_frames,
+                                           input_frame_time=input_frame_time)
 
         self.signed_spikes = signed_spikes
+        if self.signed_spikes and input_frames > 1:
+            throw NotImplementedError("Signed spike input cannot currently "
+                                      "be used with time-varying inputs ")
 
-    def get_model(self, population, dt):
+    def get_model(self, population: "Population", dt: float, batch_size: int):
         genn_model = {
-            "var_name_types": [("Input", "scalar",
-                                VarAccess_READ_ONLY_DUPLICATE)],
             "sim_code":
                 """
                 const bool spike = $(gennrand_uniform) >= exp(-fabs($(Input)) * DT);
@@ -31,4 +39,6 @@ class PoissonInput(Neuron, InputBase):
                 $(Input_pre) < 0.0 && spike
                 """
 
-        return NeuronModel(genn_model, None, {}, {"Input": 0.0})
+        neuron_model = NeuronModel(genn_model, None, {}, {"Input": 0.0})
+        self.add_input_logic(neuron_model, batch_size, population.shape)
+        return neuron_model

--- a/ml_genn/ml_genn/neurons/poisson_input.py
+++ b/ml_genn/ml_genn/neurons/poisson_input.py
@@ -38,7 +38,6 @@ class PoissonInput(Neuron, InputBase):
                 """
                 $(Input_pre) < 0.0 && spike
                 """
-
-        neuron_model = NeuronModel(genn_model, None, {}, {"Input": 0.0})
-        self.add_input_logic(neuron_model, batch_size, population.shape)
-        return neuron_model
+        return self.create_input_model(
+            NeuronModel(genn_model, None, {}, {}),
+            batch_size, population.shape)

--- a/ml_genn/ml_genn/neurons/poisson_input.py
+++ b/ml_genn/ml_genn/neurons/poisson_input.py
@@ -17,7 +17,7 @@ class PoissonInput(Neuron, InputBase):
 
         self.signed_spikes = signed_spikes
         if self.signed_spikes and input_frames > 1:
-            throw NotImplementedError("Signed spike input cannot currently "
+            raise NotImplementedError("Signed spike input cannot currently "
                                       "be used with time-varying inputs ")
 
     def get_model(self, population: "Population", dt: float, batch_size: int):

--- a/ml_genn/ml_genn/neurons/poisson_input.py
+++ b/ml_genn/ml_genn/neurons/poisson_input.py
@@ -40,4 +40,4 @@ class PoissonInput(Neuron, InputBase):
                 """
         return self.create_input_model(
             NeuronModel(genn_model, None, {}, {}),
-            batch_size, population.shape)
+            batch_size, population.shape, replace_input="$(Input)")

--- a/ml_genn/ml_genn/neurons/spike_input.py
+++ b/ml_genn/ml_genn/neurons/spike_input.py
@@ -3,7 +3,7 @@ import numpy as np
 from collections import namedtuple
 from pygenn.genn_wrapper.Models import VarAccess_READ_ONLY_DUPLICATE
 from typing import Sequence, Union
-from .input_base import InputBase
+from .input import Input
 from .neuron import Neuron
 from ..utils.data import PreprocessedSpikes 
 from ..utils.model import NeuronModel
@@ -31,7 +31,7 @@ genn_model = {
     "is_auto_refractory_required": False}
 
 
-class SpikeInput(Neuron):
+class SpikeInput(Neuron, Input):
     def __init__(self, max_spikes=1000000):
         super(SpikeInput, self).__init__()
 

--- a/ml_genn/ml_genn/neurons/spike_input.py
+++ b/ml_genn/ml_genn/neurons/spike_input.py
@@ -59,7 +59,7 @@ class SpikeInput(Neuron, Input):
         genn_pop.push_var_to_device("StartSpike")
         genn_pop.push_var_to_device("EndSpike")
 
-    def get_model(self, population: "Population", dt: float):
+    def get_model(self, population: "Population", dt: float, batch_size: int):
         return NeuronModel(genn_model, None, {}, 
                            {"StartSpike": 0, "EndSpike": 0},
                            {"SpikeTimes": np.empty(self.max_spikes)})

--- a/ml_genn/ml_genn/neurons/spike_input.py
+++ b/ml_genn/ml_genn/neurons/spike_input.py
@@ -36,17 +36,17 @@ class SpikeInput(Neuron, Input):
         super(SpikeInput, self).__init__()
 
         self.max_spikes = max_spikes
-    
+
     def set_input(self, genn_pop, batch_size: int, shape,
                   input: Union[PreprocessedSpikes, Sequence[PreprocessedSpikes]]):
         # Batch spikes
         batched_spikes = batch_spikes(input, batch_size)
-        
+
         # Get view
         start_spikes_view = genn_pop.vars["StartSpike"].view
         end_spikes_view = genn_pop.vars["EndSpike"].view
         spike_times_view = genn_pop.extra_global_params["SpikeTimes"].view
-        
+
         # Check that spike times will fit in view, copy them and push them
         num_spikes = len(batched_spikes.spike_times) 
         assert num_spikes <= len(spike_times_view)
@@ -58,7 +58,7 @@ class SpikeInput(Neuron, Input):
         start_spikes_view[:] = calc_start_spikes(batched_spikes.end_spikes)
         genn_pop.push_var_to_device("StartSpike")
         genn_pop.push_var_to_device("EndSpike")
-    
+
     def get_model(self, population: "Population", dt: float):
         return NeuronModel(genn_model, None, {}, 
                            {"StartSpike": 0, "EndSpike": 0},

--- a/ml_genn/ml_genn/population.py
+++ b/ml_genn/ml_genn/population.py
@@ -29,7 +29,7 @@ NeuronInitializer = Union[Neuron, str]
 
 class Population:
     """A population of neurons
-    
+
     Attributes:
         shape:          Shape of population
         name:           Name of connection (only really used 
@@ -39,7 +39,7 @@ class Population:
                         callbacks to this population
     """
     _new_id = count()
-    
+
     def __init__(self, neuron: NeuronInitializer, shape: Shape = None,
                  record_spikes: bool = False, 
                  record_spike_events: bool = False,
@@ -80,7 +80,7 @@ class Population:
         require no arguments, a string e.g. "leaky_integrate_fire"
         """
         return self._neuron
-    
+
     @neuron.setter
     def neuron(self, n: NeuronInitializer):
         self._neuron = get_object(n, Neuron, "Neuron", default_neurons)

--- a/ml_genn/ml_genn/synapses/delta.py
+++ b/ml_genn/ml_genn/synapses/delta.py
@@ -15,5 +15,5 @@ class Delta(Synapse):
     def __init__(self):
         super(Delta, self).__init__()
 
-    def get_model(self, connection, dt):
+    def get_model(self, connection, dt, batch_size):
         return SynapseModel(genn_model, {}, {})

--- a/ml_genn/ml_genn/synapses/exponential.py
+++ b/ml_genn/ml_genn/synapses/exponential.py
@@ -30,5 +30,5 @@ class Exponential(Synapse):
                                       "currently support tau values specified"
                                       " using Initialiser objects")
 
-    def get_model(self, connection, dt):
+    def get_model(self, connection, dt, batch_size):
         return SynapseModel.from_val_descriptors(genn_model, self, dt)

--- a/ml_genn/ml_genn/synapses/synapse.py
+++ b/ml_genn/ml_genn/synapses/synapse.py
@@ -5,5 +5,6 @@ from abc import abstractmethod, abstractproperty
 
 class Synapse(ABC):
     @abstractmethod
-    def get_model(self, connection, dt):
+    def get_model(self, connection,
+                  dt: float, batch_size: int):
         pass

--- a/ml_genn/ml_genn/utils/model.py
+++ b/ml_genn/ml_genn/utils/model.py
@@ -244,17 +244,12 @@ class NeuronModel(Model):
     def prepend_reset_code(self, code):
         self._prepend_code("reset_code", code)
 
-    def replace_input(self, replacement, source="Isyn"):
-        # Replace $(source) in all neuron code strings
-        source_neuron = f"$({source})"
-        self._replace_code("sim_code", source_neuron, replacement)
-        self._replace_code("threshold_condition_code", source_neuron,
+    def replace_input(self, replacement):
+        # Replace $(Isyn) in all neuron code strings
+        self._replace_code("sim_code", "$(Isyn)", replacement)
+        self._replace_code("threshold_condition_code", "$(Isyn)",
                            replacement)
-        self._replace_code("reset_code", source_neuron, replacement)
-
-        # Replace $(source_pre) in negative event threshold code
-        self._replace_code("negative_threshold_condition_code",
-                           f"$({source}_pre)", replacement)
+        self._replace_code("reset_code", "$(Isyn)", replacement)
 
     @staticmethod
     def from_val_descriptors(model, output_var_name, inst, dt,

--- a/ml_genn/ml_genn/utils/model.py
+++ b/ml_genn/ml_genn/utils/model.py
@@ -27,16 +27,28 @@ class Model:
         self.var_vals = var_vals
         self.egp_vals = egp_vals
 
+    def has_param(self, name):
+        return self._is_in_list("param_name_types", name)
+
+    def has_var(self, name):
+        return self._is_in_list("var_name_types", name)
+
+    def has_egp(self, name):
+        return self._is_in_list("extra_global_params", name)
+
     def add_param(self, name: str, type: str, value: Value):
+        assert not self.has_param(name)
         self._add_to_list("param_name_types", (name, type))
         self.param_vals[name] = value
 
     def add_var(self, name: str, type: str, value: Value,
                 access_mode: int = VarAccess_READ_WRITE):
+        assert not self.has_var(name)
         self._add_to_list("var_name_types", (name, type, access_mode))
         self.var_vals[name] = value
 
     def add_egp(self, name: str, type: str, value: EGPValue):
+        assert not self.has_egp(name)
         self._add_to_list("extra_global_params", (name, type))
         self.egp_vals[name] = value
     
@@ -140,6 +152,16 @@ class Model:
             self.model[name] = []
         self.model[name].append(value)
 
+    def _is_in_list(self, name: str, value):
+        if name in self.model:
+            try:
+                next(p for p in self.model[name] if p[0] == value)
+                return True
+            except StopIteration:
+                pass
+
+        return False
+
     def _append_code(self, name: str, code: str):
         code = dedent(code)
         if name not in self.model:
@@ -202,14 +224,22 @@ class CustomUpdateModel(Model):
         self.var_refs = var_refs
         self.egp_refs = egp_refs
 
+    def has_var_ref(self, name):
+        return self._is_in_list("var_refs", name)
+
+    def has_egp_ref(self, name):
+        return self._is_in_list("egp_refs", name)
+
     def add_var_ref(self, name, type, value):
+        assert not self.has_var_ref(name)
         self._add_to_list("var_refs", (name, type))
         self.var_refs[name] = value
-    
+
     def set_var_ref_access_mode(self, name, access_mode):
         self._set_access_model("var_refs", name, access_mode)
-    
+
     def add_egp_ref(self, name, type, value):
+        assert not self.has_egp_ref(name)
         self._add_to_list("egp_refs", (name, type))
         self.egp_refs[name] = value
 

--- a/ml_genn/ml_genn/utils/model.py
+++ b/ml_genn/ml_genn/utils/model.py
@@ -156,7 +156,7 @@ class Model:
 
     def _replace_code(self, name: str, source: str, target: str):
         if name in self.model:
-            self.model[name].replace(source, target)
+            self.model[name] = self.model[name].replace(source, target)
 
     def _set_access_model(self, name: str, var: str, access_mode):
         # Find var
@@ -244,12 +244,14 @@ class NeuronModel(Model):
     def prepend_reset_code(self, code):
         self._prepend_code("reset_code", code)
 
-    def replace_input(self, replacement):
-        # Replace $(Isyn) in all neuron code strings
-        self._replace_code("sim_code", "$(Isyn)", replacement)
-        self._replace_code("threshold_condition_code", "$(Isyn)",
-                           replacement)
-        self._replace_code("reset_code", "$(Isyn)", replacement)
+    def replace_sim_code(self, source: str, target: str):
+        self._replace_code("sim_code", source, target)
+
+    def replace_threshold_condition_code(self, source: str, target: str):
+        self._replace_code("threshold_condition_code", source, target)
+
+    def replace_reset_code(self, source: str, target: str):
+        self._replace_code("reset_code", source, target)
 
     @staticmethod
     def from_val_descriptors(model, output_var_name, inst, dt,


### PR DESCRIPTION
Previously mlGeNN support raw spiking inputs and various ways to turn a single 'frame' into one example-worth of spiking activity. However, sometimes you want to turn multiple frames into spiking activity within a single example e.g. Mel spectograms. 

This PR refactors most neuron inputs to support this. Main change is taht ``InputBase`` now has additional functionality to add either a state variable (for non-time varying input) or an extra global parameter (for time-varying input) to a neuron model and generate correct indexing code. This also lets standard neuron model e.g. ``IntegrateFire`` and ``LeakyIntegrateFire`` be re-used as input models trivially.

In order to use this functionality to e.g. present groups of 10 MNIST digits to an input layer of ``IntegrateFireInput`` neurons at 100 timestep intervals, you would configure IntegrateFireInput like this:
```python
IntegrateFireInput(v_thresh=5.0, input_frames=10, input_frame_time=100)
```
Then you would reshape the images appropriately like this:
```python
testing_images = np.reshape(mnist.test_images(), (-1, 10, 784))
```
and, finally, after setting the ``evaluate_timesteps`` to 1000 you would see spiking output like this:
![Figure_2](https://github.com/genn-team/ml_genn/assets/6793242/5cd90380-1998-46ac-a60a-f081508b29fb)
