### PR TITLE
Exact update for output neuron lambda_v and lambda_i

### DIFF
--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -505,7 +505,7 @@ class EventPropCompiler(Compiler):
 
                         # Add custom update to reset state
                         compile_state.add_neuron_reset_vars(
-                            pop, model_copy.reset_vars, False)
+                            pop, model_copy.reset_vars, False, False)
                     # Otherwise, if readout is MaxVar
                     elif isinstance(pop.neuron.readout, MaxVar):
                         # Add state variable to hold vmax from previous trial


### PR DESCRIPTION
Implemented changes in https://github.com/tnowotny/genn_eventprop/commit/212521e175489503fada4b9eebbe2e5a22b527aa in mlGeNN EventProp compiler. SHD and latency MNIST examples definitely still learn (using ``AvgVarExpWeight`` and ``AvgVar`` output respectively). 

Code should be easy to compare to original - only thing to note is that because we're _prepending_ a backward pass to the beginning of the neuron model, the order of code generation is backwards.