### PR TITLE
Fix typo

### DIFF
--- a/ml_genn/ml_genn/callbacks/var_recorder.py
+++ b/ml_genn/ml_genn/callbacks/var_recorder.py
@@ -13,7 +13,7 @@ from ..utils.value import get_genn_var_name
 
 
 class VarRecorder(Callback):
-    def __init__(self, pop: PopulationType, var: Optional[str], key=None,
+    def __init__(self, pop: PopulationType, var: Optional[str] = None, key = None,
                  example_filter: ExampleFilterType = None,
                  neuron_filter: NeuronFilterType = None,
                  genn_var: Optional[str] = None):

--- a/ml_genn/ml_genn/callbacks/var_recorder.py
+++ b/ml_genn/ml_genn/callbacks/var_recorder.py
@@ -13,8 +13,8 @@ from ..utils.value import get_genn_var_name
 
 
 class VarRecorder(Callback):
-    def __init__(self, pop: PopulationType, var: Optional[str] = None, key = None,
-                 example_filter: ExampleFilterType = None,
+    def __init__(self, pop: PopulationType, var: Optional[str] = None,
+                 key=None, example_filter: ExampleFilterType = None,
                  neuron_filter: NeuronFilterType = None,
                  genn_var: Optional[str] = None):
         # Get underlying population


### PR DESCRIPTION
As instructed fixed the typo in the argument list of VarRecorder callback.