### PR TITLE
Spike count record

### DIFF
--- a/examples/eprop/latency_mnist.py
+++ b/examples/eprop/latency_mnist.py
@@ -22,9 +22,10 @@ NUM_OUTPUT = 10
 BATCH_SIZE = 128
 NUM_EPOCHS = 10
 SPARSITY = 1.0
-TRAIN = True
+TRAIN = False
 KERNEL_PROFILING = False
 
+np.seterr(all='raise')
 labels = mnist.train_labels() if TRAIN else mnist.test_labels()
 spikes = log_latency_encode_data(
     mnist.train_images() if TRAIN else mnist.test_images(),

--- a/examples/eprop/latency_mnist.py
+++ b/examples/eprop/latency_mnist.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 import mnist
 
 from ml_genn import InputLayer, Layer, SequentialNetwork
-from ml_genn.callbacks import Checkpoint
+from ml_genn.callbacks import Checkpoint, SpikeRecorder
 from ml_genn.compilers import EPropCompiler, InferenceCompiler
 from ml_genn.connectivity import Dense,FixedProbability
 from ml_genn.initializers import Normal
@@ -19,7 +19,7 @@ from ml_genn.compilers.eprop_compiler import default_params
 NUM_INPUT = 784
 NUM_HIDDEN = 128
 NUM_OUTPUT = 10
-BATCH_SIZE = 128
+BATCH_SIZE = 1
 NUM_EPOCHS = 10
 SPARSITY = 1.0
 TRAIN = False
@@ -36,7 +36,7 @@ network = SequentialNetwork(default_params)
 with network:
     # Populations
     input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * calc_max_spikes(spikes)),
-                                  NUM_INPUT)
+                                  NUM_INPUT, record_spikes=True)
     initial_hidden_weight = Normal(sd=1.0 / np.sqrt(NUM_INPUT))
     connectivity = (Dense(initial_hidden_weight) if SPARSITY == 1.0 
                     else FixedProbability(SPARSITY, initial_hidden_weight))
@@ -59,10 +59,10 @@ if TRAIN:
         # Evaluate model on numpy dataset
         start_time = perf_counter()
         callbacks = ["batch_progress_bar", Checkpoint(serialiser)]
-        metrics, _  = compiled_net.train({input: spikes},
-                                         {output: labels},
-                                         num_epochs=NUM_EPOCHS, shuffle=True,
-                                         callbacks=callbacks)
+        metrics, cb_data  = compiled_net.train({input: spikes},
+                                               {output: labels},
+                                               num_epochs=NUM_EPOCHS, shuffle=True,
+                                               callbacks=callbacks)
         compiled_net.save_connectivity((NUM_EPOCHS - 1,), serialiser)
         
         end_time = perf_counter()
@@ -90,8 +90,18 @@ else:
     with compiled_net:
         # Evaluate model on numpy dataset
         start_time = perf_counter()
-        metrics, _  = compiled_net.evaluate({input: spikes},
-                                            {output: labels})
+        callbacks = ["batch_progress_bar", SpikeRecorder(input, key="input_spikes"),
+                     SpikeRecorder(input, key="input_spike_counts", record_counts=True)]
+        metrics, cb_data  = compiled_net.evaluate({input: spikes},
+                                                  {output: labels},
+                                                  callbacks=callbacks)
         end_time = perf_counter()
+
+        input_spikes = cb_data["input_spikes"]
+        input_spike_counts = cb_data["input_spike_counts"]
+
+        assert np.array_equal(np.bincount(input_spikes[1][100], minlength=NUM_INPUT),
+                              input_spike_counts[100])
+
         print(f"Accuracy = {100 * metrics[output].result}%")
         print(f"Time = {end_time - start_time}s")

--- a/examples/eprop/pattern_recognition.py
+++ b/examples/eprop/pattern_recognition.py
@@ -52,7 +52,7 @@ in_group = np.arange(NUM_INPUT, dtype=int) // IN_GROUP_SIZE
 
 # Fill matrix rows with base spike times
 num_spikes_per_neuron = IN_ACTIVE_INTERVAL // IN_ACTIVE_ISI
-in_spike_times = np.empty((NUM_INPUT, num_spikes_per_neuron))
+in_spike_times = np.empty((NUM_INPUT, num_spikes_per_neuron), dtype=np.float32)
 in_spike_times[:] = np.arange(0, IN_ACTIVE_INTERVAL, IN_ACTIVE_ISI)
 
 # Shift each spike time by group start

--- a/ml_genn/ml_genn/callbacks/spike_recorder.py
+++ b/ml_genn/ml_genn/callbacks/spike_recorder.py
@@ -114,16 +114,16 @@ class SpikeRecorder(Callback):
 
                 # Slice out batches we want
                 data_unpack = data_unpack[:, self._batch_mask, :]
-                
+
                 if self._record_counts:
                     # Loop through these batches
                     for b in range(data_unpack.shape[1]):
-                        # Calculate sum of 
+                        # Calculate number of spikes along time axis
                         # **TODO** there is a numpy PR that exposes popcount 
                         # allowing this to be done more efficiently
                         counts = np.sum(data_unpack[:, b, self._neuron_mask],
-                                        axis=2)
-                                        
+                                        axis=0)
+
                         # Add to list
                         self._spikes.append(counts)
                 else:

--- a/ml_genn/ml_genn/callbacks/var_recorder.py
+++ b/ml_genn/ml_genn/callbacks/var_recorder.py
@@ -88,7 +88,7 @@ class VarRecorder(Callback):
             var_view = pop.vars[self._var].view
             if self._batch_size > 1:
                 if self.shared:
-                    data_view = var_view[self._batch_mask][:,:]
+                    data_view = var_view[self._batch_mask][:, :]
                 else:
                     data_view = var_view[self._batch_mask][:, self._neuron_mask]
             else:

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -387,7 +387,7 @@ class Compiler:
             # Configure EGPs
             set_egp(wum_egp_vals, genn_pop.extra_global_params)
             set_egp(psm_egp_vals, genn_pop.psm_extra_global_params)
-            
+
             # Configure var init EGPs
             set_var_egps(wum_var_egp_vals, genn_pop.vars)
             set_var_egps(psm_var_egp_vals, genn_pop.psm_vars)

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -264,7 +264,7 @@ static_weight_update_model = {
         """,
     "event_threshold_condition_code": """
     $(BackSpike_pre)
-    """,}
+    """}
 
 gradient_batch_reduce_model = {
     "var_name_types": [("ReducedGradient", "scalar", VarAccess_REDUCE_BATCH_SUM)],

--- a/ml_genn/ml_genn/connectivity/avg_pool_2d.py
+++ b/ml_genn/ml_genn/connectivity/avg_pool_2d.py
@@ -12,7 +12,7 @@ from ..utils.value import is_value_constant
 
 from pygenn.genn_wrapper import (SynapseMatrixType_SPARSE_INDIVIDUALG,
                                  SynapseMatrixType_PROCEDURAL_PROCEDURALG)
-                                 
+
 genn_snippet = create_custom_sparse_connect_init_snippet_class(
     "avg_pool_2d",
 
@@ -34,12 +34,12 @@ genn_snippet = create_custom_sparse_connect_init_snippet_class(
         const int pool_sh = $(pool_sh), pool_sw = $(pool_sw);
         const int pool_iw = $(pool_iw), pool_ic = $(pool_ic);
         const int pool_oh = $(pool_oh), pool_ow = $(pool_ow), pool_oc = $(pool_oc);
-        
+
         // Convert presynaptic neuron ID to row, column and channel in pool input
         const int poolInRow = ($(id_pre) / pool_ic) / pool_iw;
         const int poolInCol = ($(id_pre) / pool_ic) % pool_iw;
         const int poolInChan = $(id_pre) % pool_ic;
-        
+
         // Calculate corresponding pool output
         const int poolOutRow = poolInRow / pool_sh;
         const int poolStrideRow = poolOutRow * pool_sh;
@@ -103,7 +103,7 @@ class AvgPool2D(Connectivity):
             "pool_sh": pool_sh, "pool_sw": pool_sw,
             "pool_ih": pool_ih, "pool_iw": pool_iw, "pool_ic": pool_ic,
             "pool_oh": pool_oh, "pool_ow": pool_ow, "pool_oc": pool_oc})
-        
+
         # Get best supported matrix type
         # **NOTE** no need to use globalg as constant weights 
         # will be turned into parameters which is equivalent

--- a/ml_genn/ml_genn/losses/mean_square_error.py
+++ b/ml_genn/ml_genn/losses/mean_square_error.py
@@ -10,7 +10,8 @@ class MeanSquareError(Loss):
         # Add extra global parameter to store Y* throughout example
         flat_shape = np.prod(shape)
         egp_size = (example_timesteps * batch_size * flat_shape)
-        model.add_egp("YTrue", "scalar*", np.empty(egp_size))
+        model.add_egp("YTrue", "scalar*",
+                      np.empty(egp_size, dtype=np.float32))
     
         # Add sim-code to read out correct yTrue value 
         model.append_sim_code(

--- a/ml_genn/ml_genn/losses/mean_square_error.py
+++ b/ml_genn/ml_genn/losses/mean_square_error.py
@@ -12,7 +12,7 @@ class MeanSquareError(Loss):
         egp_size = (example_timesteps * batch_size * flat_shape)
         model.add_egp("YTrue", "scalar*",
                       np.empty(egp_size, dtype=np.float32))
-    
+
         # Add sim-code to read out correct yTrue value 
         model.append_sim_code(
             f"""
@@ -30,10 +30,10 @@ class MeanSquareError(Loss):
         if y_true.shape != expected_shape:
             raise RuntimeError(f"Shape of target data for MeanSquareError "
                                f"loss should be {expected_shape}")
-        
+
         # Copy flattened y_true into view
         genn_pop.extra_global_params["YTrue"].view[:] = y_true.flatten()
-        
+
         # Push YTrue to device
         genn_pop.push_extra_global_param_to_device("YTrue")
 

--- a/ml_genn/ml_genn/losses/sparse_categorical_crossentropy.py
+++ b/ml_genn/ml_genn/losses/sparse_categorical_crossentropy.py
@@ -27,9 +27,9 @@ class SparseCategoricalCrossentropy(Loss):
             raise RuntimeError(f"Length of target data for "
                                f"SparseCategoricalCrossentropy loss should "
                                f"be < {batch_size}")
-        
+
         # Copy flattened y_true into view
-        genn_pop.vars["YTrue"].view[:len(y_true),0] = y_true
-        
+        genn_pop.vars["YTrue"].view[:len(y_true), 0] = y_true
+
         # Push YTrue to device
         genn_pop.push_var_to_device("YTrue")

--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -64,7 +64,8 @@ class InputBase(Input):
             if batch_size == 1:
                 # Add EGP
                 nm_copy.add_egp(self.egp_name, "scalar*",
-                                np.empty((self.input_frames,) + shape))
+                                np.empty((self.input_frames,) + shape,
+                                         dtype=np.float32))
 
                 # Prepend sim code with code to initialize
                 # local variable tosigned_spikes correct EGP entry + synaptic input
@@ -77,7 +78,8 @@ class InputBase(Input):
                 # Add EGP
                 nm_copy.add_egp(
                     self.egp_name, "scalar*",
-                    np.empty((self.input_frames, batch_size) + shape))
+                    np.empty((self.input_frames, batch_size) + shape,
+                             dtype=np.float32))
 
                 # Prepend sim code with code to initialize
                 # local variable to correct EGP entry + synaptic input

--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -68,7 +68,7 @@ class InputBase(Input):
                                          dtype=np.float32))
 
                 # Prepend sim code with code to initialize
-                # local variable tosigned_spikes correct EGP entry + synaptic input
+                # local variable to correct EGP entry + synaptic input
                 nm_copy.prepend_sim_code(
                     f"""
                     const int timestep = min((int)($(t) / ({self.input_frame_timesteps} * DT)), {self.input_frames - 1});

--- a/ml_genn/ml_genn/neurons/spike_input.py
+++ b/ml_genn/ml_genn/neurons/spike_input.py
@@ -62,4 +62,5 @@ class SpikeInput(Neuron, Input):
     def get_model(self, population: "Population", dt: float, batch_size: int):
         return NeuronModel(genn_model, None, {}, 
                            {"StartSpike": 0, "EndSpike": 0},
-                           {"SpikeTimes": np.empty(self.max_spikes)})
+                           {"SpikeTimes": np.empty(self.max_spikes,
+                                                   dtype=np.float32)})

--- a/ml_genn/ml_genn/synapses/exponential.py
+++ b/ml_genn/ml_genn/synapses/exponential.py
@@ -16,15 +16,15 @@ genn_model = {
         """
         $(inSyn) *= $(ExpDecay);
         """}
-        
+
 class Exponential(Synapse):
     tau = ValueDescriptor("ExpDecay", lambda val, dt: np.exp(-dt / val))
-    
-    def __init__(self, tau:InitValue=5.0):
+
+    def __init__(self, tau: InitValue = 5.0):
         super(Exponential, self).__init__()
-        
+
         self.tau = tau
-        
+
         if is_value_initializer(self.tau):
             raise NotImplementedError("Exponential synapse model does not "
                                       "currently support tau values specified"

--- a/ml_genn/ml_genn/utils/data.py
+++ b/ml_genn/ml_genn/utils/data.py
@@ -65,7 +65,7 @@ def permute_dataset(data: DataDictType,
             shuffled_data[k] = v[indices]
         else:
             shuffled_data[k] = [v[i] for i in indices]
-    
+
     return shuffled_data
 
 def preprocess_spikes(times: np.ndarray, ids: np.ndarray,
@@ -114,7 +114,7 @@ def preprocess_tonic_spikes(events: np.ndarray, ordering: Sequence[str],
             spike_event_ids = events["p"] + (events["x"] * shape[2])
         else:
             raise RuntimeError("Only 1D and 2D sensors supported")
-    
+
     # Preprocess scaled times and flattened IDs
     return preprocess_spikes(events["t"] * time_scale, spike_event_ids,
                              num_neurons)
@@ -129,16 +129,16 @@ def linear_latency_encode_data(data: np.ndarray, max_time: float,
     for i in range(len(data)):
         # Get boolean mask of spiking neurons
         spike_vector = data[i] > thresh
-        
+
         # Take cumulative sum to get end spikes
         end_spikes = np.cumsum(spike_vector)
-        
+
         # Extract values of spiking pixels
-        spike_pixels = data[i,spike_vector]
-        
+        spike_pixels = data[i, spike_vector]
+
         # Calculate spike times
         spike_times = (((255.0 - spike_pixels) / 255.0) * time_range) + min_time
-        
+
         # Add to list
         spikes.append(PreprocessedSpikes(end_spikes, spike_times))
 
@@ -151,16 +151,16 @@ def log_latency_encode_data(data: np.ndarray, tau_eff: float,
     for i in range(len(data)):
         # Get boolean mask of spiking neurons
         spike_vector = data[i] > thresh
-        
+
         # Take cumulative sum to get end spikes
         end_spikes = np.cumsum(spike_vector)
-            
+
         # Extract values of spiking pixels
-        spike_pixels = data[i,spike_vector]
-        
+        spike_pixels = data[i, spike_vector]
+
         # Calculate spike times
         spike_times = tau_eff * np.log(spike_pixels / (spike_pixels - thresh))
-        
+
         # Add to list
         spikes.append(PreprocessedSpikes(end_spikes, spike_times))
 
@@ -177,7 +177,7 @@ def batch_spikes(spikes: Sequence[PreprocessedSpikes],
     if any(len(s.end_spikes) != num_neurons for s in spikes):
         raise RuntimeError("Cannot batch PreprocessedSpikes "
                            "with different numbers of neurons")
-        
+
     assert all(len(s.end_spikes) == num_neurons for s in spikes)
 
     # Extract seperate lists of each example's

--- a/ml_genn/ml_genn/utils/module.py
+++ b/ml_genn/ml_genn/utils/module.py
@@ -53,7 +53,8 @@ def get_object(obj, base_class: Type[T], description: str,
                            f"either as a string or a {description} object")
 
 
-def get_object_mapping(obj, keys, base_class: Type, description:str, dictionary) -> dict:
+def get_object_mapping(obj, keys, base_class: Type,
+                       description: str, dictionary) -> dict:
     # If metrics are already in dictionary form
     if isinstance(obj, dict):
         # If keys match, process each metric and create new dictionary

--- a/ml_genn/ml_genn/utils/value.py
+++ b/ml_genn/ml_genn/utils/value.py
@@ -13,10 +13,10 @@ Value = Union[Number, Sequence[Number], np.ndarray, Initializer]
 InitValue = Union[Value, str]
 
 class ValueDescriptor:
-    def __init__(self, genn_name: str, value_transform = None):
+    def __init__(self, genn_name: str, value_transform=None):
         self.genn_name = genn_name
         self.value_transform = value_transform
-    
+
     def get_transformed(self, instance, dt):
         # Get value
         val = self.__get__(instance, None)
@@ -35,7 +35,7 @@ class ValueDescriptor:
         # Otherwise, return attribute value
         else:
             return getattr(instance, f"_{self.name}")
-    
+
     def __set__(self, instance, value):
         # **NOTE** strings are checked first as strings ARE sequences
         name_internal = f"_{self.name}"

--- a/ml_genn_tf/ml_genn_tf/converters/simple.py
+++ b/ml_genn_tf/ml_genn_tf/converters/simple.py
@@ -7,8 +7,8 @@ from .converter import Converter
 from .enum import InputType
 
 class Simple(Converter):
-    def __init__(self, evaluate_timesteps, signed_input:bool=False,
-                 input_type:InputType=InputType.POISSON):
+    def __init__(self, evaluate_timesteps, signed_input: bool = False,
+                 input_type: InputType = InputType.POISSON):
         self.evaluate_timesteps = evaluate_timesteps
         self.signed_input = signed_input
         self.input_type = InputType(input_type)
@@ -27,10 +27,10 @@ class Simple(Converter):
 
     def pre_convert(self, tf_model):
         pass
-    
+
     def pre_compile(self, mlg_network):
         pass
-    
+
     def create_compiler(self, **kwargs):
         return InferenceCompiler(evaluate_timesteps=self.evaluate_timesteps,
                                  **kwargs)


### PR DESCRIPTION
Implemented spike count recording as an option for the ``SpikeRecorder`` callback meaning that all existing filtering etc works here. The implementation could use https://github.com/numpy/numpy/pull/21429 to further improve efficiency.

```python
# Evaluate model and record spikes and spike counts of input population
callbacks = ["batch_progress_bar", SpikeRecorder(input, key="input_spikes"),
             SpikeRecorder(input, key="input_spike_counts", record_counts=True)]
metrics, cb_data  = compiled_net.evaluate({input: spikes},
                                          {output: labels},
                                          callbacks=callbacks)

# Extract spikes and spike counts
input_spikes = cb_data["input_spikes"]
input_spike_counts = cb_data["input_spike_counts"]

# Assert that manually-calculated spike counts from arbitrary example match those calculated using new system
assert np.array_equal(np.bincount(input_spikes[1][100], minlength=NUM_INPUT),
                                  input_spike_counts[100])

```
Fixes #60 