### PR TITLE
Data parallel training support

### DIFF
--- a/examples/eprop/run_shd_classifier_mpi.sh
+++ b/examples/eprop/run_shd_classifier_mpi.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export CUDA_VISIBLE_DEVICES=$OMPI_COMM_WORLD_RANK 
+python shd_classifier_mpi.py 

--- a/examples/eprop/shd_classifier_mpi.py
+++ b/examples/eprop/shd_classifier_mpi.py
@@ -1,0 +1,91 @@
+import numpy as np
+
+from ml_genn import Connection, Population, Network
+from ml_genn.callbacks import Checkpoint, VarRecorder
+from ml_genn.communicators import MPI
+from ml_genn.compilers import EPropCompiler, InferenceCompiler
+from ml_genn.connectivity import Dense
+from ml_genn.initializers import Normal
+from ml_genn.neurons import (LeakyIntegrate, AdaptiveLeakyIntegrateFire,
+                             SpikeInput)
+from ml_genn.serialisers import Numpy
+from tonic.datasets import SHD
+
+from time import perf_counter
+from ml_genn.utils.data import (calc_latest_spike_time, calc_max_spikes,
+                                preprocess_tonic_spikes)
+
+from ml_genn.compilers.eprop_compiler import default_params
+from pygenn.genn_wrapper.CUDABackend import DeviceSelect_MANUAL
+
+NUM_HIDDEN = 256
+BATCH_SIZE = 512
+NUM_EPOCHS = 50
+
+KERNEL_PROFILING = False
+
+# Get SHD dataset
+dataset = SHD(save_to='../data', train=True)
+
+# Create MPI communicator
+communicator = MPI()
+
+# Preprocess
+spikes = []
+labels = []
+for i in range(communicator.rank, len(dataset), communicator.num_ranks):
+    events, label = dataset[i]
+    spikes.append(preprocess_tonic_spikes(events, dataset.ordering,
+                                          dataset.sensor_size))
+    labels.append(label)
+
+# Determine max spikes and latest spike time
+max_spikes = calc_max_spikes(spikes)
+latest_spike_time = calc_latest_spike_time(spikes)
+print(f"Max spikes {max_spikes}, latest spike time {latest_spike_time}")
+
+# Get number of input and output neurons from dataset 
+# and round up outputs to power-of-two
+num_input = int(np.prod(dataset.sensor_size))
+num_output = len(dataset.classes)
+
+serialiser = Numpy("shd_mpi_checkpoints")
+network = Network(default_params)
+with network:
+    # Populations
+    input = Population(SpikeInput(max_spikes=BATCH_SIZE * max_spikes),
+                       num_input)
+    hidden = Population(AdaptiveLeakyIntegrateFire(v_thresh=0.6,
+                                                   tau_refrac=5.0),
+                        NUM_HIDDEN)
+    output = Population(LeakyIntegrate(tau_mem=20.0, readout="sum_var"), num_output)
+
+    # Connections
+    Connection(input, hidden, Dense(Normal(sd=1.0 / np.sqrt(num_input))))
+    Connection(hidden, hidden, Dense(Normal(sd=1.0 / np.sqrt(NUM_HIDDEN))))
+    Connection(hidden, output, Dense(Normal(sd=1.0 / np.sqrt(NUM_HIDDEN))))
+
+compiler = EPropCompiler(example_timesteps=int(np.ceil(latest_spike_time)),
+                         losses="sparse_categorical_crossentropy",
+                         optimiser="adam", batch_size=BATCH_SIZE,
+                         communicator=communicator,
+                         selectGPUByDeviceID=True,
+                         deviceSelectMethod=DeviceSelect_MANUAL)
+compiled_net = compiler.compile(network)
+
+with compiled_net:
+    # Evaluate model on SHD
+    start_time = perf_counter()
+    if communicator.rank == 0:
+        callbacks = ["batch_progress_bar", Checkpoint(serialiser)]
+    else:
+        callbacks = []
+    metrics, _  = compiled_net.train({input: spikes},
+                                        {output: labels},
+                                        num_epochs=50,
+                                        callbacks=callbacks,
+                                        shuffle=True)
+    end_time = perf_counter()
+    print(f"Accuracy = {100 * metrics[output].result}%")
+    print(f"Time = {end_time - start_time}s")
+

--- a/examples/event_prop/latency_mnist_mpi.py
+++ b/examples/event_prop/latency_mnist_mpi.py
@@ -29,13 +29,17 @@ SPARSITY = 1.0
 TRAIN = True
 KERNEL_PROFILING = True
 
-communicator = MPI()
-train_dataset_slice = slice(communicator.rank, -1, communicator.num_ranks)
-labels = mnist.train_labels()[train_dataset_slice] if TRAIN else mnist.test_labels()
-spikes = linear_latency_encode_data(
-    mnist.train_images()[train_dataset_slice] if TRAIN else mnist.test_images(),
-    EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
+if TRAIN:
+    communicator = MPI()
+    print(f"Training on rank {communicator.rank} / {communicator.num_ranks}")
+    train_dataset_slice = slice(communicator.rank, -1, communicator.num_ranks)
+    labels = mnist.train_labels()[train_dataset_slice]
+    images = mnist.train_images()[train_dataset_slice]
+else:
+    labels = mnist.test_labels()
+    images = mnist.test_images()
 
+spikes = linear_latency_encode_data(images, EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
 
 serialiser = Numpy("latency_mnist_mpi_checkpoints")
 network = SequentialNetwork(default_params)

--- a/examples/event_prop/latency_mnist_mpi.py
+++ b/examples/event_prop/latency_mnist_mpi.py
@@ -37,7 +37,7 @@ spikes = linear_latency_encode_data(
     EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
 
 
-serialiser = Numpy("latency_mnist_checkpoints")
+serialiser = Numpy("latency_mnist_mpi_checkpoints")
 network = SequentialNetwork(default_params)
 with network:
     # Populations

--- a/examples/event_prop/latency_mnist_mpi.py
+++ b/examples/event_prop/latency_mnist_mpi.py
@@ -1,0 +1,111 @@
+import numpy as np
+import mnist
+
+from ml_genn import InputLayer, Layer, SequentialNetwork
+from ml_genn.callbacks import Checkpoint
+from ml_genn.communicators import MPI
+from ml_genn.compilers import EventPropCompiler, InferenceCompiler
+from ml_genn.connectivity import Dense, FixedProbability
+from ml_genn.initializers import Normal
+from ml_genn.neurons import LeakyIntegrate, LeakyIntegrateFire, SpikeInput
+from ml_genn.optimisers import Adam
+from ml_genn.serialisers import Numpy
+from ml_genn.synapses import Exponential
+
+from time import perf_counter
+from ml_genn.utils.data import linear_latency_encode_data
+
+from ml_genn.compilers.event_prop_compiler import default_params
+from pygenn.genn_wrapper.CUDABackend import DeviceSelect_MANUAL
+
+NUM_INPUT = 784
+NUM_HIDDEN = 128
+NUM_OUTPUT = 10
+BATCH_SIZE = 32
+NUM_EPOCHS = 10
+EXAMPLE_TIME = 20.0
+DT = 1.0
+SPARSITY = 1.0
+TRAIN = True
+KERNEL_PROFILING = True
+
+communicator = MPI()
+train_dataset_slice = slice(communicator.rank, -1, communicator.num_ranks)
+labels = mnist.train_labels()[train_dataset_slice] if TRAIN else mnist.test_labels()
+spikes = linear_latency_encode_data(
+    mnist.train_images()[train_dataset_slice] if TRAIN else mnist.test_images(),
+    EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
+
+
+serialiser = Numpy("latency_mnist_checkpoints")
+network = SequentialNetwork(default_params)
+with network:
+    # Populations
+    input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * NUM_INPUT),
+                                  NUM_INPUT)
+    initial_hidden_weight = Normal(mean=0.078, sd=0.045)
+    connectivity = (Dense(initial_hidden_weight) if SPARSITY == 1.0 
+                    else FixedProbability(SPARSITY, initial_hidden_weight))
+    hidden = Layer(connectivity, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
+                                                    tau_refrac=None),
+                   NUM_HIDDEN, Exponential(5.0))
+    output = Layer(Dense(Normal(mean=0.2, sd=0.37)),
+                   LeakyIntegrate(tau_mem=20.0, readout="avg_var"),
+                   NUM_OUTPUT, Exponential(5.0))
+
+max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
+if TRAIN:
+    compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
+                                 losses="sparse_categorical_crossentropy",
+                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE,
+                                 kernel_profiling=KERNEL_PROFILING,
+                                 communicator=communicator,
+                                 selectGPUByDeviceID=True,
+                                 deviceSelectMethod=DeviceSelect_MANUAL)
+    compiled_net = compiler.compile(network)
+
+    with compiled_net:
+        # Evaluate model on numpy dataset
+        start_time = perf_counter()
+
+        if communicator.rank == 0:
+            callbacks = ["batch_progress_bar", Checkpoint(serialiser)]
+        else:
+            callbacks = []
+        metrics, cb_data  = compiled_net.train({input: spikes},
+                                               {output: labels},
+                                               num_epochs=NUM_EPOCHS, shuffle=True,
+                                               callbacks=callbacks)
+
+        if communicator.rank == 0:
+            compiled_net.save_connectivity((NUM_EPOCHS - 1,), serialiser)
+            end_time = perf_counter()
+            print(f"Accuracy = {100 * metrics[output].result}%")
+            print(f"Time = {end_time - start_time}s")
+
+            if KERNEL_PROFILING:
+                print(f"Neuron update time = {compiled_net.genn_model.neuron_update_time}")
+                print(f"Presynaptic update time = {compiled_net.genn_model.presynaptic_update_time}")
+                print(f"Gradient batch reduce time = {compiled_net.genn_model.get_custom_update_time('GradientBatchReduce')}")
+                print(f"Gradient learn time = {compiled_net.genn_model.get_custom_update_time('GradientLearn')}")
+                print(f"Reset time = {compiled_net.genn_model.get_custom_update_time('Reset')}")
+                print(f"Softmax1 time = {compiled_net.genn_model.get_custom_update_time('BatchSoftmax1')}")
+                print(f"Softmax2 time = {compiled_net.genn_model.get_custom_update_time('BatchSoftmax2')}")
+                print(f"Softmax3 time = {compiled_net.genn_model.get_custom_update_time('BatchSoftmax3')}")
+else:
+    # Load network state from final checkpoint
+    network.load((NUM_EPOCHS - 1,), serialiser)
+
+    compiler = InferenceCompiler(evaluate_timesteps=max_example_timesteps,
+                                 reset_in_syn_between_batches=True,
+                                 batch_size=BATCH_SIZE)
+    compiled_net = compiler.compile(network)
+
+    with compiled_net:
+        # Evaluate model on numpy dataset
+        start_time = perf_counter()
+        metrics, _  = compiled_net.evaluate({input: spikes},
+                                            {output: labels})
+        end_time = perf_counter()
+        print(f"Accuracy = {100 * metrics[output].result}%")
+        print(f"Time = {end_time - start_time}s")

--- a/examples/event_prop/run_latency_mnist_mpi.sh
+++ b/examples/event_prop/run_latency_mnist_mpi.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export CUDA_VISIBLE_DEVICES=$OMPI_COMM_WORLD_RANK 
+python latency_mnist_mpi.py 

--- a/ml_genn/ml_genn/__init__.py
+++ b/ml_genn/ml_genn/__init__.py
@@ -5,6 +5,7 @@ from .population import Population
 from .sequential_network import SequentialNetwork
 
 from . import callbacks
+from . import communicators
 from . import compilers
 from . import connectivity
 from . import initializers
@@ -17,9 +18,7 @@ from . import serialisers
 from . import synapses
 from . import utils
 
-__all__ = ["Connection", "InputLayer", "Layer",
-           "Network", "Population", "SequentialNetwork",
-           "callbacks", "compilers", "connectivity",
-           "initializers", "losses", "metrics",
-           "neurons", "optimisers", "readouts",
-           "serialisers", "synapses", "utils"]
+__all__ = ["Connection", "InputLayer", "Layer", "Network", "Population",
+           "SequentialNetwork", "callbacks", "communicators", "compilers",
+           "connectivity", "initializers", "losses", "metrics", "neurons",
+           "optimisers", "readouts", "serialisers", "synapses", "utils"]

--- a/ml_genn/ml_genn/communicators/__init__.py
+++ b/ml_genn/ml_genn/communicators/__init__.py
@@ -1,0 +1,4 @@
+from .communicator import Communicator
+from .mpi import MPI
+
+__all = ["Communicator", "MPI"]

--- a/ml_genn/ml_genn/communicators/communicator.py
+++ b/ml_genn/ml_genn/communicators/communicator.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from abc import ABC
+from ..compilers.compiled_network import CompiledNetwork
+
+from abc import abstractmethod, abstractproperty
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .. import Population
+
+class Communicator(ABC):
+    """Base class for all communicators - objects for abstracting away details of parallel communications between ranks
+    """
+    @abstractmethod
+    def barrier(self):
+        """Wait for all ranks to reach this point in execution before continuing
+        """
+        pass
+    
+    @abstractmethod
+    def broadcast(self, data, root: int):
+        """Broadcast data from root to all ranks
+        Args:
+            data: Data to broadcast
+            root: Index of node to broadcast from
+        """
+        pass
+
+    @abstractmethod
+    def reduce_sum(self, value):
+        """Calculates the sum of value across all ranks
+        Args:
+            value: Value to sum up
+        Returns:
+            Sum of value across all ranks
+        """
+        pass
+
+    @abstractproperty
+    def rank(self):
+        """Gets index of this rank
+
+        Returns:
+            int: rank
+        """
+        pass
+
+    @abstractproperty
+    def num_ranks(self):
+        """Gets total number of ranks
+
+        Returns:
+            int: num_ranks
+        """
+        pass

--- a/ml_genn/ml_genn/communicators/communicator.py
+++ b/ml_genn/ml_genn/communicators/communicator.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC
-from ..compilers.compiled_network import CompiledNetwork
 
 from abc import abstractmethod, abstractproperty
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .. import Population
 
 class Communicator(ABC):
     """Base class for all communicators - objects for abstracting away details of parallel communications between ranks

--- a/ml_genn/ml_genn/communicators/mpi.py
+++ b/ml_genn/ml_genn/communicators/mpi.py
@@ -1,27 +1,28 @@
+import logging
+
 from .communicator import Communicator
 
-try:
-    from mpi4py import MPI
-except ImportError:
-    _has_mpi4py = False
-else:
-    _has_mpi4py = True
-    
+logger = logging.getLogger(__name__)
+
 class MPI(Communicator):
     """Implementation of Communicator which uses mpi4py 
     for parallel communications between ranks
     """
     def __init__(self):
-        if not _has_mpi4py:
+        try:
+            from mpi4py import MPI
+        except ImportError:
             raise ImportError("mpi4py is required to use MPI communicator")
-        
+
         # Get communicator
         self.comm = MPI.COMM_WORLD
 
         # Get our rank and number of ranks
         self._rank = self.comm.Get_rank()
         self._num_ranks = self.comm.Get_size()
-        
+
+        logger.info(f"MPI communicator {self._rank}/{self._num_ranks}")
+
     def barrier(self):
         """Wait for all ranks to reach this point in execution before continuing
         """
@@ -42,8 +43,9 @@ class MPI(Communicator):
         Returns:
             Sum of value across all ranks
         """
-        return self.comm.allreduce(sendobj=value, op=MPI.SUM)
+        return self.comm.allreduce(sendobj=value)
 
+    @property
     def rank(self):
         """Gets index of this rank
 
@@ -52,10 +54,11 @@ class MPI(Communicator):
         """
         return self._rank
 
+    @property
     def num_ranks(self):
         """Gets total number of ranks
 
         Returns:
             int: num_ranks
         """
-        return self._rank
+        return self._num_ranks

--- a/ml_genn/ml_genn/communicators/mpi.py
+++ b/ml_genn/ml_genn/communicators/mpi.py
@@ -1,0 +1,61 @@
+from .communicator import Communicator
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    _has_mpi4py = False
+else:
+    _has_mpi4py = True
+    
+class MPI(Communicator):
+    """Implementation of Communicator which uses mpi4py 
+    for parallel communications between ranks
+    """
+    def __init__(self):
+        if not _has_mpi4py:
+            raise ImportError("mpi4py is required to use MPI communicator")
+        
+        # Get communicator
+        self.comm = MPI.COMM_WORLD
+
+        # Get our rank and number of ranks
+        self._rank = self.comm.Get_rank()
+        self._num_ranks = self.comm.Get_size()
+        
+    def barrier(self):
+        """Wait for all ranks to reach this point in execution before continuing
+        """
+        self.comm.Barrier()
+    
+    def broadcast(self, data, root: int):
+        """Broadcast data from root to all ranks
+        Args:
+            data: Data to broadcast
+            root: Index of node to broadcast from
+        """
+        self.comm.Bcast(data, root)
+
+    def reduce_sum(self, value):
+        """Calculates the sum of value across all ranks
+        Args:
+            value: Value to sum up
+        Returns:
+            Sum of value across all ranks
+        """
+        return self.comm.allreduce(sendobj=value, op=MPI.SUM)
+
+    def rank(self):
+        """Gets index of this rank
+
+        Returns:
+            int: rank
+        """
+        return self._rank
+
+    def num_ranks(self):
+        """Gets total number of ranks
+
+        Returns:
+            int: num_ranks
+        """
+        return self._rank

--- a/ml_genn/ml_genn/compilers/compiled_network.py
+++ b/ml_genn/ml_genn/compilers/compiled_network.py
@@ -13,10 +13,12 @@ class CompiledNetwork:
     _context = None
 
     def __init__(self, genn_model, neuron_populations,
-                 connection_populations, num_recording_timesteps=None):
+                 connection_populations, communicator,
+                 num_recording_timesteps=None):
         self.genn_model = genn_model
         self.neuron_populations = neuron_populations
         self.connection_populations = connection_populations
+        self.communicator = communicator
         self.num_recording_timesteps = num_recording_timesteps
 
     def set_input(self, inputs: dict):
@@ -57,12 +59,35 @@ class CompiledNetwork:
         if CompiledNetwork._context is not None:
             raise RuntimeError("Nested compiled networks are "
                                "not currently supported")
-
         CompiledNetwork._context = self
-        if not self.genn_model._built:
+        
+        # Build model (only on first rank if there is a communicator)
+        first_rank = (self.communicator is None 
+                      or self.communicator.rank == 0)
+        if first_rank and not self.genn_model._built:
             self.genn_model.build()
+        
+        # If there is a communicator, wait for all ranks to reach this point
+        if self.communicator is not None:
+            self.communicator.barrier()
+
         self.genn_model.load(
             num_recording_timesteps=self.num_recording_timesteps)
+
+        # If there is a communicator
+        if self.communicator is not None:
+            # Generate unique ID for our NCCL 'clique' on first rank
+            if first_rank:
+                self.genn_model._slm.nccl_generate_unique_id()
+
+            # Broadcast our  NCCL clique ID across all ranks
+            nccl_unique_id_view =\
+                self.genn_model._slm.nccl_assign_external_unique_id()
+            self.communicator.broadcast(nccl_unique_id_view, 0)
+
+            # Initialise NCCL communicator
+            self.genn_model._slm.nccl_init_communicator(
+                self.communicator.rank, self.communicator.num_ranks)
 
     def __exit__(self, dummy_exc_type, dummy_exc_value, dummy_tb):
         assert CompiledNetwork._context is not None

--- a/ml_genn/ml_genn/compilers/compiled_network.py
+++ b/ml_genn/ml_genn/compilers/compiled_network.py
@@ -61,11 +61,17 @@ class CompiledNetwork:
                                "not currently supported")
         CompiledNetwork._context = self
 
-        # Build model (only on first rank if there is a communicator)
+        # If model, isn't already built
         first_rank = (self.communicator is None 
                       or self.communicator.rank == 0)
-        if first_rank and not self.genn_model._built:
-            self.genn_model.build()
+        if not self.genn_model._built:
+            # If this is the first rank, build model
+            if first_rank:
+                self.genn_model.build()
+            # Otherwise, at least ensure it is finalised
+            # **HACK** GeNN should handle this
+            else:
+                self.genn_model._model.finalize()
 
         # If there is a communicator, wait for all ranks to reach this point
         if self.communicator is not None:

--- a/ml_genn/ml_genn/compilers/compiled_network.py
+++ b/ml_genn/ml_genn/compilers/compiled_network.py
@@ -60,13 +60,13 @@ class CompiledNetwork:
             raise RuntimeError("Nested compiled networks are "
                                "not currently supported")
         CompiledNetwork._context = self
-        
+
         # Build model (only on first rank if there is a communicator)
         first_rank = (self.communicator is None 
                       or self.communicator.rank == 0)
         if first_rank and not self.genn_model._built:
             self.genn_model.build()
-        
+
         # If there is a communicator, wait for all ranks to reach this point
         if self.communicator is not None:
             self.communicator.barrier()

--- a/ml_genn/ml_genn/compilers/compiled_training_network.py
+++ b/ml_genn/ml_genn/compilers/compiled_training_network.py
@@ -39,7 +39,7 @@ class CompiledTrainingNetwork(CompiledNetwork):
         self.checkpoint_connection_vars = checkpoint_connection_vars
         self.checkpoint_population_vars = checkpoint_population_vars
         self.reset_time_between_batches = reset_time_between_batches
-        
+
         # Build set of synapse groups with checkpoint variables
         self.checkpoint_synapse_groups = set(
             connection_populations[c] 
@@ -166,7 +166,7 @@ class CompiledTrainingNetwork(CompiledNetwork):
                 step_i += 1
 
             train_callback_list.on_epoch_end(e, train_metrics)
-            
+
             # If there's any validation data
             if x_validate_size > 0:
                 # Reset validation metrics at start of each epoch
@@ -223,7 +223,7 @@ class CompiledTrainingNetwork(CompiledNetwork):
             # connectivity so variables can be accessed correctly
             if genn_pop.is_ragged:
                 genn_pop.pull_connectivity_from_device()
-                
+
         # Loop through connection variables to checkpoint
         for c, v in self.checkpoint_connection_vars:
             genn_pop = self.connection_populations[c]
@@ -258,8 +258,9 @@ class CompiledTrainingNetwork(CompiledNetwork):
 
         # Update metrics
         for (o, y_true), out_y_pred in zip(y.items(), y_pred):
-            metrics[o].update(y_true, out_y_pred[:len(y_true)])
-        
+            metrics[o].update(y_true, out_y_pred[:len(y_true)],
+                              self.communicator)
+
         # End batch
         callback_list.on_batch_end(batch, metrics)
 
@@ -294,7 +295,8 @@ class CompiledTrainingNetwork(CompiledNetwork):
 
         # Update metrics
         for (o, y_true), out_y_pred in zip(y.items(), y_pred):
-            metrics[o].update(y_true, out_y_pred[:len(y_true)])
+            metrics[o].update(y_true, out_y_pred[:len(y_true)],
+                              self.communicator)
 
         # Loop through optimiser custom updates and set step
         for c in self.optimiser_custom_updates:

--- a/ml_genn/ml_genn/compilers/compiled_training_network.py
+++ b/ml_genn/ml_genn/compilers/compiled_training_network.py
@@ -19,8 +19,8 @@ from ..serialisers import default_serialisers
 
 class CompiledTrainingNetwork(CompiledNetwork):
     def __init__(self, genn_model, neuron_populations,
-                 connection_populations, losses,
-                 optimiser, example_timesteps: int, 
+                 connection_populations, communicator,
+                 losses, optimiser, example_timesteps: int,
                  base_train_callbacks: list, base_validate_callbacks: list,
                  optimiser_custom_updates: list,
                  checkpoint_connection_vars: list,
@@ -28,7 +28,7 @@ class CompiledTrainingNetwork(CompiledNetwork):
                  reset_time_between_batches: bool = True):
         super(CompiledTrainingNetwork, self).__init__(
             genn_model, neuron_populations, connection_populations,
-            example_timesteps)
+            communicator, example_timesteps)
 
         self.losses = losses
         self.optimiser = optimiser

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -296,12 +296,12 @@ class Compiler:
 
         # If we are using a communicator, generate NCCL reductions
         # **NOTE** this only works with CUDA backend
-        kwargs = copy(self.genn_kwargs)
+        genn_kwargs = copy(self.genn_kwargs)
         if self.communicator is not None:
-            kwargs["enableNCCLReductions"] = True
+            genn_kwargs["enableNCCLReductions"] = True
 
         # Create GeNN model and set basic properties
-        genn_model = GeNNModel("float", clean_name, **kwargs)
+        genn_model = GeNNModel("float", clean_name, **genn_kwargs)
         genn_model.dT = self.dt
         genn_model.batch_size = self.batch_size
         genn_model._model.set_seed(self.rng_seed)

--- a/ml_genn/ml_genn/compilers/eprop_compiler.py
+++ b/ml_genn/ml_genn/compilers/eprop_compiler.py
@@ -8,6 +8,7 @@ from . import Compiler
 from .compiled_training_network import CompiledTrainingNetwork
 from ..callbacks import (BatchProgressBar, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnTimestepEnd)
+from ..communicators import Communicator
 from ..losses import Loss, SparseCategoricalCrossentropy
 from ..neurons import (AdaptiveLeakyIntegrateFire, Input,
                        LeakyIntegrate, LeakyIntegrateFire, 
@@ -245,12 +246,14 @@ class EPropCompiler(Compiler):
                  f_target: float = 10.0, train_output_bias: bool = True,
                  dt: float = 1.0, batch_size: int = 1,
                  rng_seed: int = 0, kernel_profiling: bool = False,
-                 reset_time_between_batches: bool = True, **genn_kwargs):
+                 reset_time_between_batches: bool = True,
+                 communicator: Communicator = None, **genn_kwargs):
         supported_matrix_types = [SynapseMatrixType_SPARSE_INDIVIDUALG,
                                   SynapseMatrixType_DENSE_INDIVIDUALG]
         super(EPropCompiler, self).__init__(supported_matrix_types, dt,
                                             batch_size, rng_seed,
                                             kernel_profiling,
+                                            communicator,
                                             **genn_kwargs)
         self.example_timesteps = example_timesteps
         self.losses = losses
@@ -392,7 +395,7 @@ class EPropCompiler(Compiler):
         if not is_value_constant(connect_snippet.delay):
             raise NotImplementedError("E-prop compiler only "
                                       "support heterogeneous delays")
-        
+
         # Calculate membrane persistence
         alpha = np.exp(-self.dt / compile_state.tau_mem)
 
@@ -412,7 +415,7 @@ class EPropCompiler(Compiler):
         elif isinstance(target_neuron, AdaptiveLeakyIntegrateFire):
             # Calculate adaptation variable persistence
             rho = np.exp(-self.dt / compile_state.tau_adapt)
-            
+
             wum = WeightUpdateModel(
                 model=eprop_alif_model,
                 param_vals={"CReg": self.c_reg, "Alpha": alpha, "Rho": rho, 
@@ -452,7 +455,7 @@ class EPropCompiler(Compiler):
         # Correctly target feedback
         for c in compile_state.feedback_connections:
             connection_populations[c].pre_target_var = "ISynFeedback"
-        
+
         # Add optimisers to connection weights that require them
         optimiser_custom_updates = []
         for i, c in enumerate(compile_state.weight_optimiser_connections):
@@ -461,7 +464,7 @@ class EPropCompiler(Compiler):
                 self._create_optimiser_custom_update(
                     f"Weight{i}", create_wu_var_ref(genn_pop, "g"),
                     create_wu_var_ref(genn_pop, "DeltaG"), genn_model))
-        
+
         # Add optimisers to population biases that require them
         for i, p in enumerate(compile_state.bias_optimiser_populations):
             genn_pop = neuron_populations[p]
@@ -469,7 +472,7 @@ class EPropCompiler(Compiler):
                 self._create_optimiser_custom_update(
                     f"Bias{i}", create_var_ref(genn_pop, "Bias"),
                     create_var_ref(genn_pop, "DeltaBias"), genn_model))
-        
+
         # Loop through populations requiring softmax
         # calculation and add requisite custom updates
         for p, o, s in compile_state.softmax_populations:
@@ -504,9 +507,9 @@ class EPropCompiler(Compiler):
 
         return CompiledTrainingNetwork(
             genn_model, neuron_populations, connection_populations,
-            compile_state.losses, self._optimiser, self.example_timesteps,
-            base_train_callbacks, base_validate_callbacks, 
-            optimiser_custom_updates,
+            self.communicator, compile_state.losses, self._optimiser,
+            self.example_timesteps, base_train_callbacks,
+            base_validate_callbacks, optimiser_custom_updates,
             compile_state.checkpoint_connection_vars,
             compile_state.checkpoint_population_vars, self.reset_time_between_batches)
 

--- a/ml_genn/ml_genn/compilers/eprop_compiler.py
+++ b/ml_genn/ml_genn/compilers/eprop_compiler.py
@@ -488,7 +488,7 @@ class EPropCompiler(Compiler):
         base_train_callbacks = []
         base_validate_callbacks = []
         if len(optimiser_custom_updates) > 0:
-            if self.batch_size > 1:
+            if self.full_batch_size > 1:
                 base_train_callbacks.append(CustomUpdateOnBatchEnd("GradientBatchReduce"))
             base_train_callbacks.append(CustomUpdateOnBatchEnd("GradientLearn"))
         if compile_state.is_reset_custom_update_required:
@@ -516,7 +516,7 @@ class EPropCompiler(Compiler):
     def _create_optimiser_custom_update(self, name_suffix, var_ref,
                                         gradient_ref, genn_model):
         # If batch size is greater than 1
-        if self.batch_size > 1:
+        if self.full_batch_size > 1:
             # Create custom update model to reduce DeltaG into a variable 
             reduction_optimiser_model = CustomUpdateModel(
                 gradient_batch_reduce_model, {}, {"ReducedGradient": 0.0},

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -672,10 +672,12 @@ class EventPropCompiler(Compiler):
                         # Add parameters for regulariser
                         model_copy.add_param("RegNuUpper", "int",
                                              self.reg_nu_upper)
-                        model_copy.add_param("RegLambdaUpper", "int",
-                                             self.reg_lambda_upper / self.batch_size)
-                        model_copy.add_param("RegLambdaLower", "int",
-                                             self.reg_lambda_lower / self.batch_size)
+                        model_copy.add_param(
+                            "RegLambdaUpper", "int",
+                            self.reg_lambda_upper / self.full_batch_size)
+                        model_copy.add_param(
+                            "RegLambdaLower", "int",
+                            self.reg_lambda_lower / self.full_batch_size)
 
                         # Add reset variables to copy SpikeCount
                         # into SpikeCountBack and zero SpikeCount
@@ -829,7 +831,7 @@ class EventPropCompiler(Compiler):
         base_train_callbacks = []
         base_validate_callbacks = []
         if len(optimiser_custom_updates) > 0:
-            if self.batch_size > 1:
+            if self.full_batch_size > 1:
                 base_train_callbacks.append(
                     CustomUpdateOnBatchEnd("GradientBatchReduce"))
             base_train_callbacks.append(
@@ -933,7 +935,7 @@ class EventPropCompiler(Compiler):
     def _create_optimiser_custom_update(self, name_suffix, var_ref,
                                         gradient_ref, genn_model):
         # If batch size is greater than 1
-        if self.batch_size > 1:
+        if self.full_batch_size > 1:
             # Create custom update model to reduce Gradient into a variable 
             reduction_optimiser_model = CustomUpdateModel(
                 gradient_batch_reduce_model, {}, {"ReducedGradient": 0.0},

--- a/ml_genn/ml_genn/compilers/few_spike_compiler.py
+++ b/ml_genn/ml_genn/compilers/few_spike_compiler.py
@@ -169,7 +169,8 @@ class CompiledFewSpikeNetwork(CompiledNetwork):
 
                     # Update metrics
                     metrics[o].update(batch_y_true,
-                                      batch_y_pred[:len(batch_y_true)])
+                                      batch_y_pred[:len(batch_y_true)],
+                                      self.communicator)
 
             # End batch
             callback_list.on_batch_end(batch_i, metrics)

--- a/ml_genn/ml_genn/compilers/few_spike_compiler.py
+++ b/ml_genn/ml_genn/compilers/few_spike_compiler.py
@@ -29,7 +29,8 @@ class CompiledFewSpikeNetwork(CompiledNetwork):
                  connection_populations, k: int,
                  pop_pipeline_depth: dict):
         super(CompiledFewSpikeNetwork, self).__init__(
-              genn_model, neuron_populations, connection_populations, k)
+              genn_model, neuron_populations, connection_populations,
+              None, k)
 
         self.k = k
         self.pop_pipeline_depth = pop_pipeline_depth

--- a/ml_genn/ml_genn/compilers/inference_compiler.py
+++ b/ml_genn/ml_genn/compilers/inference_compiler.py
@@ -32,7 +32,7 @@ class CompiledInferenceNetwork(CompiledNetwork):
                  reset_time_between_batches: bool = True):
         super(CompiledInferenceNetwork, self).__init__(
             genn_model, neuron_populations, connection_populations,
-            evaluate_timesteps)
+            None, evaluate_timesteps)
         
         self.evaluate_timesteps = evaluate_timesteps
         self.base_callbacks = base_callbacks

--- a/ml_genn/ml_genn/compilers/inference_compiler.py
+++ b/ml_genn/ml_genn/compilers/inference_compiler.py
@@ -254,7 +254,8 @@ class CompiledInferenceNetwork(CompiledNetwork):
 
         # Update metrics
         for (o, y_true), out_y_pred in zip(y.items(), y_pred):
-            metrics[o].update(y_true, out_y_pred[:len(y_true)])
+            metrics[o].update(y_true, out_y_pred[:len(y_true)],
+                              self.communicator)
 
         # End batch
         callback_list.on_batch_end(batch, metrics)

--- a/ml_genn/ml_genn/compilers/inference_compiler.py
+++ b/ml_genn/ml_genn/compilers/inference_compiler.py
@@ -5,6 +5,7 @@ from pygenn.genn_wrapper.Models import VarAccessMode_READ_WRITE
 from .compiler import Compiler, ZeroInSyn
 from .compiled_network import CompiledNetwork
 from ..callbacks import BatchProgressBar, CustomUpdateOnBatchBegin
+from ..communicators import Communicator
 from ..metrics import Metric
 from ..synapses import Delta
 from ..utils.callback_list import CallbackList
@@ -27,13 +28,13 @@ from ..metrics import default_metrics
 
 class CompiledInferenceNetwork(CompiledNetwork):
     def __init__(self, genn_model, neuron_populations,
-                 connection_populations, evaluate_timesteps: int, 
-                 base_callbacks: list,
+                 connection_populations, communicator,
+                 evaluate_timesteps: int, base_callbacks: list,
                  reset_time_between_batches: bool = True):
         super(CompiledInferenceNetwork, self).__init__(
             genn_model, neuron_populations, connection_populations,
-            None, evaluate_timesteps)
-        
+            communicator, evaluate_timesteps)
+
         self.evaluate_timesteps = evaluate_timesteps
         self.base_callbacks = base_callbacks
         self.reset_time_between_batches = reset_time_between_batches
@@ -264,7 +265,7 @@ class CompileState:
         self._neuron_reset_vars = {}
         self._psm_reset_vars = {}
         self.in_syn_zero_conns = []
-    
+
     def add_neuron_reset_vars(self, model, pop, reset_model_vars):
         if reset_model_vars:
             reset_vars = model.reset_vars
@@ -280,7 +281,7 @@ class CompileState:
         reset_vars = model.reset_vars
         if len(reset_vars) > 0:
             self._psm_reset_vars[conn] = reset_vars
-    
+
     def create_reset_custom_updates(self, compiler, genn_model,
                                     neuron_pops, conn_pops):
         # Loop through neuron variables to reset
@@ -314,6 +315,7 @@ class InferenceCompiler(Compiler):
                  reset_time_between_batches=True,
                  reset_vars_between_batches=True,
                  reset_in_syn_between_batches=False,
+                 communicator: Communicator = None,
                  **genn_kwargs):
         # Determine matrix type order of preference based on flag
         if prefer_in_memory_connect:
@@ -330,7 +332,8 @@ class InferenceCompiler(Compiler):
                                      SynapseMatrixType_DENSE_INDIVIDUALG]
         super(InferenceCompiler, self).__init__(supported_matrix_type, dt,
                                                 batch_size, rng_seed,
-                                                kernel_profiling, 
+                                                kernel_profiling,
+                                                communicator,
                                                 **genn_kwargs)
         self.evaluate_timesteps = evaluate_timesteps
         self.reset_time_between_batches = reset_time_between_batches
@@ -387,6 +390,7 @@ class InferenceCompiler(Compiler):
 
         return CompiledInferenceNetwork(genn_model, neuron_populations,
                                         connection_populations,
+                                        self.communicator,
                                         self.evaluate_timesteps,
                                         base_callbacks,
                                         self.reset_time_between_batches)

--- a/ml_genn/ml_genn/metrics/mean_square_error.py
+++ b/ml_genn/ml_genn/metrics/mean_square_error.py
@@ -21,8 +21,8 @@ class MeanSquareError(Metric):
 
         # If a communicator is provided, sum number correct and total across batch
         if communicator is not None:
-            batch_sum_mse = communicator.reduce_sum(batch_correct)
-            batch_total = communicator.reduce_sum(batch_sum_mse)
+            batch_sum_mse = communicator.reduce_sum(batch_sum_mse)
+            batch_total = communicator.reduce_sum(batch_total)
 
         # Add total size and MSE sum across batch to totals
         self.sum_mse += batch_sum_mse

--- a/ml_genn/ml_genn/metrics/metric.py
+++ b/ml_genn/ml_genn/metrics/metric.py
@@ -1,11 +1,12 @@
 from abc import ABC
+from ..communicators import Communicator
 
 from abc import abstractmethod, abstractproperty
 
 
 class Metric(ABC):
     @abstractmethod
-    def update(self, y_true, y_pred):
+    def update(self, y_true, y_pred, communicator: Communicator):
         pass
 
     @abstractmethod

--- a/ml_genn/ml_genn/metrics/sparse_categorical_accuracy.py
+++ b/ml_genn/ml_genn/metrics/sparse_categorical_accuracy.py
@@ -22,7 +22,7 @@ class SparseCategoricalAccuracy(Metric):
         # If a communicator is provided, sum number correct and total across batch
         if communicator is not None:
             batch_correct = communicator.reduce_sum(batch_correct)
-            batch_total = communicator.reduce_sum(batch_correct)
+            batch_total = communicator.reduce_sum(batch_total)
 
         # Add total size and number correct in batch to totals
         self.correct += batch_correct

--- a/ml_genn/ml_genn/metrics/sparse_categorical_accuracy.py
+++ b/ml_genn/ml_genn/metrics/sparse_categorical_accuracy.py
@@ -1,23 +1,32 @@
 import numpy as np
 
 from .metric import Metric
-
+from ..communicators import Communicator
 
 class SparseCategoricalAccuracy(Metric):
     def __init__(self):
         self.reset()
 
-    def update(self, y_true, y_pred):
+    def update(self, y_true, y_pred, communicator: Communicator):
         y_true = np.asarray(y_true)
         if y_true.shape[0] != y_pred.shape[0]:
             raise RuntimeError(f"Prediction shape:{y_pred.shape} does "
                                f"not match label shape:{y_true.shape}")
 
         # Add number of one-hot predictions which match labels to correct
-        self.correct += np.sum((np.argmax(y_pred, axis=1) == y_true))
+        batch_correct = np.sum((np.argmax(y_pred, axis=1) == y_true))
 
         # Add shape of true
-        self.total += y_true.shape[0]
+        batch_total = y_true.shape[0]
+
+        # If a communicator is provided, sum number correct and total across batch
+        if communicator is not None:
+            batch_correct = communicator.reduce_sum(batch_correct)
+            batch_total = communicator.reduce_sum(batch_correct)
+
+        # Add total size and number correct in batch to totals
+        self.correct += batch_correct
+        self.total += batch_total
 
     def reset(self):
         self.total = 0

--- a/ml_genn/ml_genn/neurons/leaky_integrate.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate.py
@@ -28,7 +28,7 @@ class LeakyIntegrate(Neuron):
             "var_name_types": [("V", "scalar")],
             "param_name_types": [("Alpha", "scalar"), ("Bias", "scalar")],
             "is_auto_refractory_required": False}
-        
+
         # Define integration code based on whether I should be scaled
         if self.scale_i:
             genn_model["sim_code"] = "$(V) = ($(Alpha) * $(V)) + ((1.0 - $(Alpha)) * $(Isyn));"

--- a/ml_genn_tf/ml_genn_tf/converters/few_spike.py
+++ b/ml_genn_tf/ml_genn_tf/converters/few_spike.py
@@ -34,13 +34,13 @@ class FewSpike(Converter):
         if len(pre_conv_alpha) > 0 and tf_layer not in pre_conv_alpha:
             logger.warning(f"FewSpike pre_convert has not provided "
                            f"an alpha value for '{tf_layer.name}'")
-            
+
         # Lookup optimised alpha value for neuron
         alpha = (pre_conv_alpha[tf_layer] if tf_layer in pre_conv_alpha
                  else self.alpha)
         return FewSpikeRelu(self.k, alpha, 
                             readout="var" if is_output else None)
-    
+
     def pre_convert(self, tf_model):
         # If any normalisation data was provided
         if self.norm_data is not None:
@@ -71,7 +71,7 @@ class FewSpike(Converter):
         # Otherwise, return empty normalisation output tuple
         else:
             return PreConvertOutput(layer_alpha={}, input_alpha=None)
-    
+
     def post_convert(self, mlg_network, mlg_network_inputs, mlg_model_outputs):
         # Loop through populations
         for p in mlg_network.populations:
@@ -80,11 +80,11 @@ class FewSpike(Converter):
                 # Determine the maximum alpha value of presynaptic populations
                 max_presyn_alpha = max(c().source().neuron.alpha 
                                        for c in p.incoming_connections)
-                
+
                 # Loop through incoming connections
                 for c in p.incoming_connections:
                     # Set presyn alpha to maximum alpha of all presyn layers
                     c().source().neuron.alpha = max_presyn_alpha
-    
+
     def create_compiler(self, **kwargs):
         return FewSpikeCompiler(k=self.k, **kwargs)


### PR DESCRIPTION
Pleasingly, this was actually very easy to do! Basically:
- There's a new class of things called 'communicators' which let you get rank, number of ranks etc and perform basic communications - I've made an ``mpi4py`` implementation for now as that's what my old code used
- ``CompiledNetwork`` does some basic stuff  if a communicator is provided:
   -  Only building on the 1st rank
   -  Waiting on a barrier before loading
   - Doing  the NCCL initialisation
- ``Compiler`` subdivides batches across ranks if a communicator is provided and turns on the magic NCCL flag so GeNN generates the additional bits of code (https://github.com/genn-team/genn/pull/449)
- Metrics like ``SparseCategoricalAccuracy`` get passed the communicator and use it to

Other than that, it's all just passing the communicator around and a few places where the 'full' batch size is used rather than the scaled down one e.g. in the EventProp compiler to scale stuff. I've also added a couple of additional examples (at some point I need to tidy the examples up a bit) which demonstrate how you need to change your code to run across multiple GPUs - mostly just splitting the dataset and turning off progress bars etc apart from on the first rank.