### PR TITLE
Get raw predictions from CompiledInferenceNetwork

### DIFF
--- a/ml_genn/ml_genn/compilers/inference_compiler.py
+++ b/ml_genn/ml_genn/compilers/inference_compiler.py
@@ -235,7 +235,6 @@ class CompiledInferenceNetwork(CompiledNetwork):
         # Return predictions from model
         return self.get_readout(outputs)
 
-
     def _evaluate_batch(self, batch: int, x: dict, y: dict, metrics,
                         callback_list: CallbackList):
         """ Evaluate a single batch of inputs against labels


### PR DESCRIPTION
As ever, have taken inspiration from Keras for this but to obtain raw predictions rather than evaluate metrics from an inference network you do:
```python
predictions, _ = compiled_net.predict({input: testing_images * 0.01},
                                      output)
```
rather than:
```python
metrics, _ = compiled_net.evaluate({input: testing_images * 0.01},
                                   {output: testing_labels})
```
The result will be a dictionary mapping output populations to ``(dataset_size, num_output_neurons)`` numpy arrays containing the raw readout values i.e. spike counts or average var value