### PR TITLE
warn if no key is provided for a recorder

### DIFF
--- a/ml_genn/ml_genn/utils/callback_list.py
+++ b/ml_genn/ml_genn/utils/callback_list.py
@@ -118,7 +118,9 @@ class CallbackList:
 
                 # Add data to dictionary, using index of
                 # callback as key if key is not provided
-                key = i if key is None else key
+                if key is None:
+                    warn(f"No key provided - a default numerical key {i} will be used")
+                    key = i
                 if key in cb_data:
                     raise KeyError(f"Callback data key {key} is not unique")
                 cb_data[key] = data

--- a/ml_genn/ml_genn/utils/callback_list.py
+++ b/ml_genn/ml_genn/utils/callback_list.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from typing import List, Sequence
+from warnings import warn
 
 from ..callbacks import Callback
 

--- a/tests/ml_genn/utils/test_callback_list.py
+++ b/tests/ml_genn/utils/test_callback_list.py
@@ -1,0 +1,30 @@
+from ml_genn.callbacks import Callback
+from ml_genn.utils.callback_list import CallbackList
+
+from pytest import raises, warns
+
+def test_missing_key():
+    # Create fake callback which returns None as it's data key
+    class NoKeyCallback(Callback):
+        def get_data(self):
+            return None, "hello"
+
+    # Place one in callback list
+    cb_list = CallbackList([NoKeyCallback()])
+
+    # Check that warning is emitted when getting data
+    with warns():
+        data = cb_list.get_data()
+
+def test_duplicate_key():
+    # Create fake callback which returns fixed key
+    class FixedKeyCallback(Callback):
+        def get_data(self):
+            return "key", "hello"
+
+    # Place one in callback list
+    cb_list = CallbackList([FixedKeyCallback(), FixedKeyCallback()])
+
+    # Check that exception is raised when getting data
+    with raises(KeyError):
+        data = cb_list.get_data()


### PR DESCRIPTION
just using a default integer key is very confusing.