### PR TITLE
Weight quantization

### DIFF
--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -32,10 +32,11 @@ from copy import deepcopy
 from pygenn.genn_model import (create_egp_ref, create_var_ref,
                                create_wu_var_ref)
 from .compiler import create_reset_custom_update
-from .quantisation import SignedWeightQuantise
+from .weight_quantisation import WeightQuantiseBatch, WeightQuantiseTrain
 from ..utils.module import get_object, get_object_mapping
 from ..utils.network import get_underlying_pop
-from ..utils.value import is_value_constant
+from ..utils.quantisation import quantise_signed
+from ..utils.value import is_value_constant, is_value_initializer
 
 from pygenn.genn_wrapper import (SynapseMatrixType_DENSE_INDIVIDUALG,
                                  SynapseMatrixType_SPARSE_INDIVIDUALG,
@@ -132,6 +133,8 @@ class CompileState:
         self.timestep_softmax_populations = []
         self.feedback_connections = []
         self.update_trial_pops = []
+        self.batch_quantise_connections = []
+        self.train_quantise_connections = []
 
     def add_neuron_reset_vars(self, pop, reset_vars, 
                               reset_event_ring, reset_v_ring):
@@ -755,6 +758,7 @@ class EventPropCompiler(Compiler):
                                       "support heterogeneous delays")
 
         # If this is some form of trainable connectivity
+        quantise_enabled = (self.quantise_num_weight_bits is not None)
         if connect_snippet.trainable:
             # **NOTE** this is probably not necessary as 
             # it's also checked in build_neuron_model
@@ -776,31 +780,57 @@ class EventPropCompiler(Compiler):
                 model=deepcopy(weight_update_model_atomic_cuda if use_atomic
                                else weight_update_model),
                 param_vals={"TauSyn": tau_syn},
-                var_vals={"g": connect_snippet.weight, "Gradient": 0.0})
+                var_vals={"Gradient": 0.0})
             # Add weights to list of checkpoint vars
             compile_state.checkpoint_connection_vars.append((conn, "g"))
 
             # Add connection to list of connections to optimise
             compile_state.weight_optimiser_connections.append(conn)
+            
+            # If quantisation is enabled
+            if quantise_enabled:
+                # Initially zero the quantised forward weight
+                wum.var_vals["g"] = 0.0
+
+                # Add additional state variable to hold unquantised weight
+                wum.add_var("gBack", "scalar", connect_snippet.weight,
+                            VarAccess.READ_ONLY)
+    
+                # Also checkpoint this variable
+                compile_state.checkpoint_connection_vars.append(
+                    (conn, "gBack"))
+
+                # Add connection to list of those 
+                # requiring quantisation every batch
+                compile_state.batch_quantise_connections.append(conn)
+            # Otherwise, initialise forward weights directly
+            else:
+                wum.var_vals["g"] = connect_snippet.weight
         # Otherwise, e.g. it's a pooling layer
         else:
-            wum = WeightUpdateModel(model=deepcopy(static_weight_update_model),
-                                    param_vals={"g": connect_snippet.weight})
+            wum = WeightUpdateModel(model=deepcopy(static_weight_update_model))
 
-        # If weights should be quantised
-        if self.quantise_num_weight_bits is not None:
-            # Add additional variable to hold quantised forward weight
-            wum.add_var("gQuant", "scalar", 0.0, VarAccess.READ_ONLY)
-            
-            # Append forward pass using this
-            wum.append_pre_spike_syn_code("addToPost(gQuant);")
-
-            # Add to list of checkpoint variables
-            if connect_snippet.trainable:
-                compile_state.checkpoint_connection_vars.append((conn, "gQuant"))
-        # Otherwise, append standard forward pass
-        else:
-            wum.append_pre_spike_syn_code("addToPost(g);")
+            # If quantisation is enabled
+            if quantise_enabled:
+                # If weight is initialised on device
+                if is_value_initializer(connect_snippet.weight):
+                    # Initially zero the quantised forward weight
+                    # and force it to be implemented as a variable
+                    wum.param_vals["g"] = 0.0
+                    wum.make_param_var("g")
+                    
+                    # Add connection to list of those 
+                    # requiring quantisation at start of training
+                    compile_state.train_quantise_connections.append(conn)
+                # Otherwise, directly initialise 
+                # forward weights with quantised version
+                else:
+                    wum.param_vals["g"] = quantise_signed(
+                        connect_snippet.weight, self.quantise_num_weight_bits,
+                        self.quantise_weight_percentile)
+            # Otherwise, initialise forward weights directly
+            else:
+                wum.param_vals["g"] = connect_snippet.weight
 
         # If source neuron isn't an input neuron
         source_neuron = conn.source().neuron
@@ -809,8 +839,11 @@ class EventPropCompiler(Compiler):
             compile_state.feedback_connections.append(conn)
 
             # If it's LIF, add additional event code to backpropagate gradient
+            weight = ("gBack" 
+                      if quantise_enabled and connect_snippet.trainable
+                      else "g")
             if isinstance(source_neuron, LeakyIntegrateFire):
-                wum.append_event_code("$(addToPre, $(g) * ($(LambdaV_post) - $(LambdaI_post)));")
+                wum.append_event_code(f"$(addToPre, $({weight}) * ($(LambdaV_post) - $(LambdaI_post)));")
 
         # Return weight update model
         return wum
@@ -825,9 +858,10 @@ class EventPropCompiler(Compiler):
         optimiser_custom_updates = []
         for i, c in enumerate(compile_state.weight_optimiser_connections):
             genn_pop = connection_populations[c]
+            weight = "g" if self.quantise_num_weight_bits is None else "gBack"
             optimiser_custom_updates.append(
                 self._create_optimiser_custom_update(
-                    f"Weight{i}", create_wu_var_ref(genn_pop, "g"),
+                    f"Weight{i}", create_wu_var_ref(genn_pop, weight),
                     create_wu_var_ref(genn_pop, "Gradient"), genn_model))
 
         # Add per-batch softmax custom updates for each population that requires them
@@ -886,16 +920,20 @@ class EventPropCompiler(Compiler):
         if compile_state.is_reset_custom_update_required:
             base_train_callbacks.append(CustomUpdateOnBatchBegin("Reset"))
             base_validate_callbacks.append(CustomUpdateOnBatchBegin("Reset"))
+
+        # Add batch quantisation callbacks for connections that require it
+        for c in compile_state.batch_quantise_connections:
+            base_train_callbacks.append(
+                WeightQuantiseBatch(connection_populations[c], "gBack", "g",
+                                    self.quantise_weight_percentile,
+                                    self.quantise_num_weight_bits))
         
-        # If quantisation is enabled
-        if self.quantise_num_weight_bits is not None:
-            # Loop through connection_populations 
-            # and add weight quantisation callbacks
-            for sg in connection_populations.values():
-                base_train_callbacks.append(
-                    SignedWeightQuantise(
-                        sg, "g", "gQuant", self.quantise_weight_percentile,
-                        self.quantise_num_weight_bits))
+        # Add train quantisation callbacks for connections that require it
+        for c in compile_state.train_quantise_connections:
+            base_train_callbacks.append(
+                WeightQuantiseTrain(connection_populations[c], "gBack", "g",
+                                    self.quantise_weight_percentile,
+                                    self.quantise_num_weight_bits))
 
         return CompiledTrainingNetwork(
             genn_model, neuron_populations, connection_populations,

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -794,7 +794,7 @@ class EventPropCompiler(Compiler):
 
                 # Add additional state variable to hold unquantised weight
                 wum.add_var("gBack", "scalar", connect_snippet.weight,
-                            VarAccess.READ_ONLY)
+                            VarAccess_READ_ONLY)
     
                 # Also checkpoint this variable
                 compile_state.checkpoint_connection_vars.append(
@@ -808,7 +808,8 @@ class EventPropCompiler(Compiler):
                 wum.var_vals["g"] = connect_snippet.weight
         # Otherwise, e.g. it's a pooling layer
         else:
-            wum = WeightUpdateModel(model=deepcopy(static_weight_update_model))
+            wum = WeightUpdateModel(
+                model=deepcopy(static_weight_update_model))
 
             # If quantisation is enabled
             if quantise_enabled:

--- a/ml_genn/ml_genn/compilers/quantisation.py
+++ b/ml_genn/ml_genn/compilers/quantisation.py
@@ -1,14 +1,16 @@
 import math
 import numpy as np
 
+from pygenn import VarAccess
 from ..callbacks import Callback
-from ..utils.quantisation import find_signed_scale
+from ..utils.quantisation import quantise_signed
 
 class SignedWeightQuantise(Callback):
     def __init__(self, synapse_group, weight_var_name,
-                 percentile, num_weight_bits):
+                 quant_weight_var_name, percentile, num_weight_bits):
         self.synapse_group = synapse_group
         self.weight_var = synapse_group.vars[weight_var_name]
+        self.quant_weight_var = synapse_group.vars[quant_weight_var_name]
         self.percentile = percentile
         self.num_weight_bits = num_weight_bits
 
@@ -16,27 +18,8 @@ class SignedWeightQuantise(Callback):
         # Download weights
         self.weight_var.pull_from_device()
         
-        # Find scaling factors
-        min_quant, max_quant, scale = find_signed_scale(self.weight_var.view,
+        # Quantise and push to device
+        self.quant_weight_var.view[:] = quantise_signed(self.weight_var.view,
                                                         self.num_weight_bits,
                                                         self.percentile)
-
-        # Apply to synapse group
-        self.synapse_group.set_dynamic_param_value("MinWeight", min_quant)
-        self.synapse_group.set_dynamic_param_value("MaxWeight", max_quant)
-        self.synapse_group.set_dynamic_param_value("WeightScale", scale)
-
-def add_wum_quantisation(wum, weight_var_name):
-    # Add quantization parameters to weight update model
-    wum.add_param("MinWeight", "scalar", 0.0)
-    wum.add_param("MaxWeight", "scalar", 0.0)
-    wum.add_param("WeightScale", "scalar", 0.0)
-
-    # Make all dynamic
-    wum.set_param_dynamic("MinWeight")
-    wum.set_param_dynamic("MaxWeight")
-    wum.set_param_dynamic("WeightScale")
-
-    # Add code to inject quantised
-    wum.append_pre_spike_syn_code(
-        f"addToPost(fmin(MaxWeight, fmax(MinWeight, WeightScale * round({weight_var_name} / WeightScale))));")
+        self.quant_weight_var.push_to_device()

--- a/ml_genn/ml_genn/compilers/quantisation.py
+++ b/ml_genn/ml_genn/compilers/quantisation.py
@@ -1,0 +1,42 @@
+import math
+import numpy as np
+
+from ..callbacks import Callback
+from ..utils.quantisation import find_signed_scale
+
+class SignedWeightQuantise(Callback):
+    def __init__(self, synapse_group, weight_var_name,
+                 percentile, num_weight_bits):
+        self.synapse_group = synapse_group
+        self.weight_var = synapse_group.vars[weight_var_name]
+        self.percentile = percentile
+        self.num_weight_bits = num_weight_bits
+
+    def on_batch_begin(self, batch):
+        # Download weights
+        self.weight_var.pull_from_device()
+        
+        # Find scaling factors
+        min_quant, max_quant, scale = find_signed_scale(self.weight_var.view,
+                                                        self.num_weight_bits,
+                                                        self.percentile)
+
+        # Apply to synapse group
+        self.synapse_group.set_dynamic_param_value("MinWeight", min_quant)
+        self.synapse_group.set_dynamic_param_value("MaxWeight", max_quant)
+        self.synapse_group.set_dynamic_param_value("WeightScale", scale)
+
+def add_wum_quantisation(wum, weight_var_name):
+    # Add quantization parameters to weight update model
+    wum.add_param("MinWeight", "scalar", 0.0)
+    wum.add_param("MaxWeight", "scalar", 0.0)
+    wum.add_param("WeightScale", "scalar", 0.0)
+
+    # Make all dynamic
+    wum.set_param_dynamic("MinWeight")
+    wum.set_param_dynamic("MaxWeight")
+    wum.set_param_dynamic("WeightScale")
+
+    # Add code to inject quantised
+    wum.append_pre_spike_syn_code(
+        f"addToPost(fmin(MaxWeight, fmax(MinWeight, WeightScale * round({weight_var_name} / WeightScale))));")

--- a/ml_genn/ml_genn/compilers/weight_quantisation.py
+++ b/ml_genn/ml_genn/compilers/weight_quantisation.py
@@ -1,7 +1,6 @@
 import math
 import numpy as np
 
-from pygenn import VarAccess
 from ..callbacks import Callback
 from ..utils.quantisation import quantise_signed
 
@@ -9,20 +8,21 @@ class WeightQuantiseBase(Callback):
     def __init__(self, synapse_group, weight_var_name,
                  quant_weight_var_name, percentile, num_weight_bits):
         self.synapse_group = synapse_group
-        self.weight_var = synapse_group.vars[weight_var_name]
-        self.quant_weight_var = synapse_group.vars[quant_weight_var_name]
+        self.weight_var_name = weight_var_name
+        self.quant_weight_var_name = quant_weight_var_name
         self.percentile = percentile
         self.num_weight_bits = num_weight_bits
 
     def _apply(self):
         # Download weights
-        self.weight_var.pull_from_device()
+        self.synapse_group.pull_var_from_device(self.weight_var_name)
         
         # Quantise and push to device
-        self.quant_weight_var.view[:] = quantise_signed(self.weight_var.view,
-                                                        self.num_weight_bits,
-                                                        self.percentile)
-        self.quant_weight_var.push_to_device()
+        view = self.synapse_group.vars[self.weight_var_name].view
+        quant_view = self.synapse_group.vars[self.quant_weight_var_name].view
+        quant_view[:] = quantise_signed(view, self.num_weight_bits,
+                                        self.percentile)
+        self.synapse_group.push_var_to_device(self.quant_weight_var_name)
         
 class WeightQuantiseBatch(WeightQuantiseBase):
     def on_batch_begin(self, batch):

--- a/ml_genn/ml_genn/compilers/weight_quantisation.py
+++ b/ml_genn/ml_genn/compilers/weight_quantisation.py
@@ -5,7 +5,7 @@ from pygenn import VarAccess
 from ..callbacks import Callback
 from ..utils.quantisation import quantise_signed
 
-class SignedWeightQuantise(Callback):
+class WeightQuantiseBase(Callback):
     def __init__(self, synapse_group, weight_var_name,
                  quant_weight_var_name, percentile, num_weight_bits):
         self.synapse_group = synapse_group
@@ -14,7 +14,7 @@ class SignedWeightQuantise(Callback):
         self.percentile = percentile
         self.num_weight_bits = num_weight_bits
 
-    def on_batch_begin(self, batch):
+    def _apply(self):
         # Download weights
         self.weight_var.pull_from_device()
         
@@ -23,3 +23,11 @@ class SignedWeightQuantise(Callback):
                                                         self.num_weight_bits,
                                                         self.percentile)
         self.quant_weight_var.push_to_device()
+        
+class WeightQuantiseBatch(WeightQuantiseBase):
+    def on_batch_begin(self, batch):
+        self._apply()
+
+class WeightQuantiseTrain(WeightQuantiseBase):
+    def on_train_begin(self):
+        self._apply()

--- a/ml_genn/ml_genn/utils/quantisation.py
+++ b/ml_genn/ml_genn/utils/quantisation.py
@@ -1,0 +1,66 @@
+import math
+import numpy as np
+
+def find_signed_scale(data, num_bits: int, percentile: float):
+    # Split data into positive and negative
+    positive_mask = (data > 0)
+    positive_data = data[positive_mask]
+    negative_data = data[np.logical_not(positive_mask)]
+
+    # Calculate desired percentile
+    positive_perc = np.percentile(positive_data, percentile)
+    negative_perc = np.percentile(-negative_data, percentile)
+
+    # Calculate the largest of these
+    max_val = max(positive_perc, negative_perc)
+    
+    # Calculate high bit and low bit
+    # **NOTE** we floor so max is 2**(high_bit + 1) - 1
+    # **NOTE** one bit is used for sign
+    high_bit =  math.floor(math.log(max_val, 2))
+    low_bit = high_bit - (num_bits - 2)
+    
+    # We scale to multiples of the low bit
+    scale = (2.0 ** low_bit)
+    
+    # Calculate min and max
+    min_quant = (-2.0 ** (high_bit + 1))
+    max_quant = (2.0 ** (high_bit + 1)) - scale
+
+    # Return range and scale
+    return min_quant, max_quant, scale
+
+def find_unsigned_scale(data, num_bits: int, percentile: float):
+    # Calculate desired percentile
+    perc = np.percentile(data, percentile)
+    
+    # Calculate high bit and low bit
+    # **NOTE** we floor so max is 2**(high_bit + 1) - 1
+    high_bit = math.floor(math.log(perc, 2))
+    low_bit = high_bit - (num_bits - 1)
+
+    # We scale to multiples of the low bit
+    scale = (2.0 ** low_bit)
+    
+    # Calculate max
+    max_quant = (2.0 ** (high_bit + 1)) - scale
+    
+    # Return range and scale
+    return 0.0, max_quant, scale
+
+def quantise_signed(data, num_bits: int, percentile: float):
+    # Find scaling factors
+    min_quant, max_quant, scale = find_signed_scale(data, num_bits,
+                                                    percentile)
+
+    # Quantise, clip and return
+    return np.clip(scale * np.round(data / scale), min_quant, max_quant)
+
+
+def quantise_unsigned(data, num_bits: int, percentile: float):
+    # Find scaling factors
+    min_quant, max_quant, scale = find_unsigned_scale(data, num_bits,
+                                                      percentile)
+
+    # Quantise, clip and return
+    return np.clip(scale * np.round(data / scale), min_quant, max_quant)

--- a/ml_genn/ml_genn/utils/quantisation.py
+++ b/ml_genn/ml_genn/utils/quantisation.py
@@ -1,18 +1,24 @@
 import math
 import numpy as np
 
+from numbers import Number
+
 def find_signed_scale(data, num_bits: int, percentile: float):
-    # Split data into positive and negative
-    positive_mask = (data > 0)
-    positive_data = data[positive_mask]
-    negative_data = data[np.logical_not(positive_mask)]
-
     # Calculate desired percentile
-    positive_perc = np.percentile(positive_data, percentile)
-    negative_perc = np.percentile(-negative_data, percentile)
+    if isinstance(data, Number):
+        max_val = data
+    else:
+        # Split data into positive and negative
+        positive_mask = (data > 0)
+        positive_data = data[positive_mask]
+        negative_data = data[np.logical_not(positive_mask)]
 
-    # Calculate the largest of these
-    max_val = max(positive_perc, negative_perc)
+        # Calculate desired percentile
+        positive_perc = np.percentile(positive_data, percentile)
+        negative_perc = np.percentile(-negative_data, percentile)
+
+        # Calculate the largest of these
+        max_val = max(positive_perc, negative_perc)
     
     # Calculate high bit and low bit
     # **NOTE** we floor so max is 2**(high_bit + 1) - 1
@@ -32,7 +38,10 @@ def find_signed_scale(data, num_bits: int, percentile: float):
 
 def find_unsigned_scale(data, num_bits: int, percentile: float):
     # Calculate desired percentile
-    perc = np.percentile(data, percentile)
+    if isinstance(data, Number):
+        perc = data
+    else:
+        perc = np.percentile(data, percentile)
     
     # Calculate high bit and low bit
     # **NOTE** we floor so max is 2**(high_bit + 1) - 1


### PR DESCRIPTION
I am going to add support to the e-prop compiler before I merge this but thought I'd open a PR for a sanity check. Basic design is:

## Quantisation helpers
Take some percentile (99% of un-quantised weight distribution) and fit a fixed point format to it

## Quantisation callbacks
Pulls weights, calculates quantised version using helper and pushes

## Event prop compiler
* Uses standard ``g`` variable for quantised version of the weight so, when checkpoints are loaded into inference compiler, quantised weights these will be used
* Adds second ``gBack`` to trainable weights to hold unquantised weight which gradients get applied to
* At beginning of each batch, quantisation callback is applied to 
* Untrained weights are quantised in place, either with a callback at the start of training if they are initialised using GeNN or by calling the helper directly if raw values are provided.

Works nicely on MNIST,
