### PR TITLE
fix egp index for input current with  batch size 1

### DIFF
--- a/ml_genn/ml_genn/neurons/input.py
+++ b/ml_genn/ml_genn/neurons/input.py
@@ -105,7 +105,7 @@ class InputBase(Input):
                 nm_copy.prepend_sim_code(
                     f"""
                     const int timestep = min((int)(t / ({self.input_frame_timesteps} * dt)), {self.input_frames - 1});
-                    const scalar input = {self.egp_name}[(t * {flat_shape}) + id];
+                    const scalar input = {self.egp_name}[(timestep * {flat_shape}) + id];
                     """)
             else:
                 # Add EGP


### PR DESCRIPTION
For batch size 1, `t` instead of `timestep` was used to read from the egp, which caused an error in the compilation of the GeNN model. It should use `timestep` as in the case where `batch_size > 1`.