### PR TITLE
Event-prop bug fixes

### DIFF
--- a/examples/event_prop/latency_mnist.py
+++ b/examples/event_prop/latency_mnist.py
@@ -27,6 +27,7 @@ SPARSITY = 1.0
 TRAIN = True
 KERNEL_PROFILING = True
 
+mnist.datasets_url = "https://storage.googleapis.com/cvdf-datasets/mnist/"
 labels = mnist.train_labels() if TRAIN else mnist.test_labels()
 spikes = linear_latency_encode_data(
     mnist.train_images() if TRAIN else mnist.test_images(),

--- a/examples/simple_mnist.py
+++ b/examples/simple_mnist.py
@@ -24,6 +24,7 @@ compiler = InferenceCompiler(dt=1.0, batch_size=BATCH_SIZE,
 compiled_net = compiler.compile(network)
 
 # Load testing data
+mnist.datasets_url = "https://storage.googleapis.com/cvdf-datasets/mnist/"
 testing_images = np.reshape(mnist.test_images(), (-1, 784))
 testing_labels = mnist.test_labels()
 

--- a/ml_genn/ml_genn/callbacks/__init__.py
+++ b/ml_genn/ml_genn/callbacks/__init__.py
@@ -3,6 +3,7 @@ from .callback import Callback
 from .checkpoint import Checkpoint
 from .conn_var_recorder import ConnVarRecorder
 from .custom_update import (CustomUpdateOnBatchBegin, CustomUpdateOnBatchEnd,
+                            CustomUpdateOnEpochBegin, CustomUpdateOnEpochEnd,
                             CustomUpdateOnTimestepBegin, CustomUpdateOnTimestepEnd)
 from .optimiser_param_schedule import OptimiserParamSchedule
 from .progress_bar import BatchProgressBar

--- a/ml_genn/ml_genn/callbacks/custom_update.py
+++ b/ml_genn/ml_genn/callbacks/custom_update.py
@@ -40,6 +40,24 @@ class CustomUpdateOnBatchEnd(CustomUpdate):
         self._custom_update()
 
 
+class CustomUpdateOnEpochBegin(CustomUpdate):
+    """Callback that triggers a GeNN custom update 
+    at the beginning of every epoch."""
+    def on_epoch_begin(self, epoch):
+        logger.debug(f"Running custom update {self.name} "
+                     f"at start of epoch {epoch}")
+        self._custom_update()
+
+
+class CustomUpdateOnEpochEnd(CustomUpdate):
+    """Callback that triggers a GeNN custom update 
+    at the end of every epoch."""
+    def on_epoch_end(self, epoch, metrics):
+        logger.debug(f"Running custom update {self.name} "
+                     f"at end of epoch {epoch}")
+        self._custom_update()
+
+
 class CustomUpdateOnTimestepBegin(CustomUpdate):
     """Callback that triggers a GeNN custom update 
     at the beginning of every timestep."""

--- a/ml_genn/ml_genn/compilers/compiled_training_network.py
+++ b/ml_genn/ml_genn/compilers/compiled_training_network.py
@@ -48,28 +48,32 @@ class CompiledTrainingNetwork(CompiledNetwork):
     def train(self, x: dict, y: dict, num_epochs: int, 
               start_epoch: int = 0, shuffle: bool = True,
               metrics: MetricsType = "sparse_categorical_accuracy",
-              callbacks=[BatchProgressBar()], validation_split: float = 0.0,
+              callbacks=[BatchProgressBar()],
+              validation_callbacks=[BatchProgressBar()],
+              validation_split: float = 0.0,
               validation_x: Optional[dict] = None, 
               validation_y: Optional[dict] = None):
         """ Train model on an input in numpy format against labels
 
         Args:
-            x:                  Dictionary of training inputs
-            y:                  Dictionary of training labels 
-                                to compare predictions against
-            num_epochs:         Number of epochs to train for
-            start_epoch:        Epoch to stasrt training from
-            shuffle:            Should training data be shuffled between epochs?
-            metrics:            Metrics to calculate.
-            callbacks:          List of callbacks to run during training.
-            validation_split:   Float between 0 and 1 specifying the fraction
-                                of the training data to use for validation.
-            validation_x:       Dictionary of validation inputs (cannot be
-                                used at same time as ``validation_split``)
-            validation_y:       Dictionary of validation labels (cannot be
-                                used at same time as ``validation_split``)
-        """
-        
+            x:                      Dictionary of training inputs
+            y:                      Dictionary of training labels 
+                                    to compare predictions against
+            num_epochs:             Number of epochs to train for
+            start_epoch:            Epoch to stasrt training from
+            shuffle:                Should training data be shuffled
+                                    between epochs?
+            metrics:                Metrics to calculate.
+            callbacks:              List of callbacks to run during training.
+            validation_callbacks:   List of callbacks to run during validation
+            validation_split:       Float between 0 and 1 specifying the
+                                    fraction of the training data to use
+                                    for validation.
+            validation_x:           Dictionary of validation inputs (cannot be
+                                    used at same time as ``validation_split``)
+            validation_y:           Dictionary of validation labels (cannot be
+                                    used at same time as ``validation_split``)
+        """        
         # If validation split is specified
         if validation_split != 0.0:
             # Check validation data isn't also provided
@@ -140,7 +144,7 @@ class CompiledTrainingNetwork(CompiledNetwork):
             # Create seperate callback list and begin testing
             num_validate_batches = (x_validate_size + batch_size - 1) // batch_size
             validate_callback_list = CallbackList(
-                self.base_validate_callbacks + callbacks,
+                self.base_validate_callbacks + validation_callbacks,
                 compiled_network=self,
                 num_batches=num_validate_batches, 
                 num_epochs=num_epochs)


### PR DESCRIPTION
This PR fixes several issues which somehow only came to light when trying to train SSC.

1. Gradients were being optimised and reduced in 1st batch when they are invalid
2. During validation, gradients are still accumulated - this is fine but they weren't being zeroed before the next epoch of training. An additional custom update is now generated to do this.

Also, this PR modifies ``CompiledTrainingNetwork.train`` to take a seperate list of validation callbacks, preventing irritating issues around e.g. checkpointing and learning rate schedules.