### PR TITLE
EventProp fixes

### DIFF
--- a/examples/event_prop/shd.py
+++ b/examples/event_prop/shd.py
@@ -21,8 +21,7 @@ from ml_genn.compilers.event_prop_compiler import default_params
 
 NUM_HIDDEN = 256
 BATCH_SIZE = 32
-NUM_EPOCHS = 300
-EXAMPLE_TIME = 20.0
+NUM_EPOCHS = 100
 DT = 1.0
 TRAIN = True
 KERNEL_PROFILING = True

--- a/examples/event_prop/shd.py
+++ b/examples/event_prop/shd.py
@@ -73,7 +73,7 @@ max_example_timesteps = int(np.ceil(latest_spike_time / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 reg_lambda_upper=4e-09, reg_lambda_lower=4e-09, 
+                                 reg_lambda_upper=2.5e-10, reg_lambda_lower=2.5e-10, 
                                  reg_nu_upper=14, max_spikes=1500, 
                                  optimiser=Adam(0.001), batch_size=BATCH_SIZE, 
                                  kernel_profiling=KERNEL_PROFILING)

--- a/ml_genn/ml_genn/callbacks/conn_var_recorder.py
+++ b/ml_genn/ml_genn/callbacks/conn_var_recorder.py
@@ -12,7 +12,6 @@ from ..utils.network import ConnectionType
 from pygenn import get_var_access_dim
 from ..utils.filter import get_neuron_filter_mask
 from ..utils.network import get_underlying_conn
-from ..utils.value import get_genn_var_name
 from ..connection import Connection
 
 logger = logging.getLogger(__name__)

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -956,7 +956,7 @@ class EventPropCompiler(Compiler):
 
                         # Add additional transition code to apply regularisation
                         transition_code += """
-                        if (SpikeCountBackSum > RegNuUpperBatch) {
+                        if (SpikeCountBackBatch > RegNuUpperBatch) {
                             LambdaV -= RegLambdaUpper * (SpikeCountBackBatch - RegNuUpperBatch);
                         }
                         else {
@@ -1357,8 +1357,8 @@ class EventPropCompiler(Compiler):
             reduction_optimiser_model = CustomUpdateModel(
                 spike_count_batch_reduce_model, {}, {},
                 {"SpikeCount": create_var_ref(genn_pop, "SpikeCount"),
-                 "SpikeCountBatch": neuron_group(genn_pop, 
-                                                 "SpikeCountBackBatch")})
+                 "SpikeCountBatch": create_var_ref(genn_pop, 
+                                                  "SpikeCountBackBatch")})
 
             # Add GeNN custom update to model
             self.add_custom_update(

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -86,7 +86,8 @@ default_params = {
                          "scale_i": True},
     LeakyIntegrateFireInput: {"relative_reset": False, 
                               "integrate_during_refrac": False,
-                              "scale_i": True}}
+                              "scale_i": True},
+    Exponential: {"scale_i": True}}
 
 def _get_tau_syn(pop):
     # Loop through incoming connections

--- a/ml_genn/ml_genn/neurons/adaptive_leaky_integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/adaptive_leaky_integrate_fire.py
@@ -42,9 +42,9 @@ class AdaptiveLeakyIntegrateFire(Neuron):
     v = ValueDescriptor("V")
     a = ValueDescriptor("A")
     beta = ValueDescriptor("Beta")
-    tau_mem = ValueDescriptor("Alpha", lambda val, dt: np.exp(-dt / val))
+    tau_mem = ValueDescriptor(("Alpha", lambda val, dt: np.exp(-dt / val)))
     tau_refrac = ValueDescriptor("TauRefrac")
-    tau_adapt = ValueDescriptor("Rho", lambda val, dt: np.exp(-dt / val))
+    tau_adapt = ValueDescriptor(("Rho", lambda val, dt: np.exp(-dt / val)))
     
     @network_default_params
     def __init__(self, v_thresh: InitValue = 1.0, v_reset: InitValue = 0.0,

--- a/ml_genn/ml_genn/neurons/leaky_integrate.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate.py
@@ -25,7 +25,7 @@ class LeakyIntegrate(Neuron):
     
     v = ValueDescriptor("V")
     bias = ValueDescriptor("Bias")
-    tau_mem = ValueDescriptor("Alpha", lambda val, dt: np.exp(-dt / val))
+    tau_mem = ValueDescriptor(("Alpha", lambda val, dt: np.exp(-dt / val)))
 
     @network_default_params
     def __init__(self, v: InitValue = 0.0, bias: InitValue = 0.0,

--- a/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
+++ b/ml_genn/ml_genn/neurons/leaky_integrate_fire.py
@@ -36,7 +36,7 @@ class LeakyIntegrateFire(Neuron):
     v_thresh = ValueDescriptor("Vthresh")
     v_reset = ValueDescriptor("Vreset")
     v = ValueDescriptor("V")
-    tau_mem = ValueDescriptor("Alpha", lambda val, dt: np.exp(-dt / val))
+    tau_mem = ValueDescriptor(("Alpha", lambda val, dt: np.exp(-dt / val)))
     tau_refrac = ValueDescriptor("TauRefrac")
 
     @network_default_params

--- a/ml_genn/ml_genn/synapses/exponential.py
+++ b/ml_genn/ml_genn/synapses/exponential.py
@@ -12,13 +12,7 @@ if TYPE_CHECKING:
 
 from ..utils.value import is_value_initializer
 
-genn_model = {
-    "params": [("ExpDecay", "scalar")],
-    "sim_code":
-        """
-        injectCurrent(inSyn);
-        inSyn *= ExpDecay;
-        """}
+from ..utils.decorators import network_default_params
 
 class Exponential(Synapse):
     """Synapse model where inputs produce 
@@ -27,12 +21,15 @@ class Exponential(Synapse):
     Args:
         tau:    Time constant of input current [ms]
     """
-    tau = ValueDescriptor(("ExpDecay", lambda val, dt: np.exp(-dt / val)))
+    tau = ValueDescriptor(("ExpDecay", lambda val, dt: np.exp(-dt / val)),
+                          ("IScale", lambda val, dt: (val / dt) * (1.0 - np.exp(-dt / val))))
 
-    def __init__(self, tau: InitValue = 5.0):
+    @network_default_params
+    def __init__(self, tau: InitValue = 5.0, scale_i : bool = False):
         super(Exponential, self).__init__()
 
         self.tau = tau
+        self.scale_i = scale_i
 
         if is_value_initializer(self.tau):
             raise NotImplementedError("Exponential synapse model does not "
@@ -41,4 +38,21 @@ class Exponential(Synapse):
 
     def get_model(self, connection: Connection,
                   dt: float, batch_size: int) -> SynapseModel:
+        # Add exponential decay parameter
+        genn_model = {"params": [("ExpDecay", "scalar")]}
+        
+        # If we should scale I, add additional parameter
+        # and create sim code to inject scaled current
+        if self.scale_i:
+            genn_model["params"].append(("IScale", "scalar"))
+            genn_model["sim_code"] = "injectCurrent(inSyn * IScale);"
+        # Otherwise, create sim code to inject unscaled current
+        else:
+            genn_model["sim_code"] = "injectCurrent(inSyn);"
+        
+        # Add standard sim code
+        genn_model["sim_code"] += """
+        inSyn *= ExpDecay;
+        """
+
         return SynapseModel.from_val_descriptors(genn_model, self, dt)

--- a/ml_genn/ml_genn/synapses/exponential.py
+++ b/ml_genn/ml_genn/synapses/exponential.py
@@ -27,7 +27,7 @@ class Exponential(Synapse):
     Args:
         tau:    Time constant of input current [ms]
     """
-    tau = ValueDescriptor("ExpDecay", lambda val, dt: np.exp(-dt / val))
+    tau = ValueDescriptor(("ExpDecay", lambda val, dt: np.exp(-dt / val)))
 
     def __init__(self, tau: InitValue = 5.0):
         super(Exponential, self).__init__()

--- a/ml_genn/ml_genn/utils/value.py
+++ b/ml_genn/ml_genn/utils/value.py
@@ -80,9 +80,19 @@ def get_genn_var_name(inst, name):
     # Get attribute from instance type
     d = getattr(type(inst), name)
 
-    # If attribute is a value descriptor, return GeNN name
+    # If attribute is a value descriptor
     if isinstance(d, ValueDescriptor):
-        return d.genn_name
+        # Find all untransformed GeNN variables it is responsible for
+        t = [g[0] for g in d.genn_transforms
+             if g[1] is None]
+        
+        # If there aren't any, give error
+        if len(t) == 0:
+            raise RuntimeError(f"There are no GenN variables which "
+                               f"directly map to varaible'{name}'")
+        # Otherwise, return first
+        else:
+            return t[0]
     else:
         raise RuntimeError(f"'{name}' is not a ValueDescriptor")
 

--- a/ml_genn/ml_genn/utils/value.py
+++ b/ml_genn/ml_genn/utils/value.py
@@ -13,19 +13,21 @@ Value = Union[Number, Sequence[Number], np.ndarray, Initializer]
 InitValue = Union[Value, str]
 
 class ValueDescriptor:
-    def __init__(self, genn_name: str, value_transform=None):
-        self.genn_name = genn_name
-        self.value_transform = value_transform
+    def __init__(self, *args):
+        # Args are either strings specifying the names of GeNN variables
+        # without transforms or tuples specifying names and transforms
+        self.genn_transforms = [(a, None) if isinstance(a, str)
+                                else a for a in args]
 
     def get_transformed(self, instance, dt):
         # Get value
         val = self.__get__(instance, None)
 
-        # Apply transform if specified and return
-        return (val if self.value_transform is None 
-                else self.value_transform(val, dt))
+        # Apply transforms to get dictionary of GeNN variables
+        return {g[0]: (val if g[1] is None else g[1](val, dt))
+                for g in self.genn_transforms}
 
-    def __set_name__(self, owner, name: str, genn_name: str = None):
+    def __set_name__(self, owner, name: str, *args):
         self.name = name
 
     def __get__(self, instance, owner):
@@ -39,7 +41,7 @@ class ValueDescriptor:
     def __set__(self, instance, value):
         # **NOTE** strings are checked first as strings ARE sequences
         name_internal = f"_{self.name}"
-        if (self.value_transform is not None 
+        if (any(g[1] is not None for g in self.genn_transforms)
                 and isinstance(value, (str, Initializer))):
             raise NotImplementedError(f"{self.name} variable has a "
                                       f"transformation and cannot be "
@@ -90,15 +92,15 @@ def get_values(inst, name_types, dt, vals={}):
     # Get descriptors
     descriptors = getmembers(type(inst), isdatadescriptor)
 
-    # Build dictionary mapping GeNN names to var descriptors
-    descriptors = {d.genn_name: d for n, d in descriptors
-                   if (isinstance(d, ValueDescriptor)
-                       and d.genn_name is not None)}
+    names = set(n[0] for n in name_types)
 
-    # Return map of GeNN names and transformed values provided by descriptor
-    vals.update({v[0]: descriptors[v[0]].get_transformed(inst, dt)
-                 for v in name_types
-                 if v[0] in descriptors})
+    # Loop through descriptors
+    for n, d in descriptors:
+        # If this is a value descriptor
+        if isinstance(d, ValueDescriptor):
+            vals.update({g: v for g, v in d.get_transformed(inst, dt).items()
+                         if g in names})
+    
     return vals
 
 

--- a/tests/ml_genn/utils/test_value.py
+++ b/tests/ml_genn/utils/test_value.py
@@ -6,7 +6,7 @@ from ml_genn.utils.value import get_genn_var_name, get_values
 class Model:
     x = ValueDescriptor("X")
     y = ValueDescriptor("Y")
-    z = ValueDescriptor("Z", lambda val, dt: val * dt)
+    z = ValueDescriptor(("Z", lambda val, dt: val * dt))
 
     def __init__(self, x, y, z):
         self.x = x


### PR DESCRIPTION
This branch contains several EventProp fixes that have emerged from my recent debugging deep dive:
* LIF + ExpCurr neuron model were not matching Thomas's code with exact integration. Slightly extended ``ValueDescriptor`` system to enable multiple derived GeNN variables to be calculated from a single Python parameter to tidily implement scale factor already present in GeNN ExpCurr model. This is configured via the standard compiler ``default_params`` mechanism.
* I think because we reset time every batch, the ring buffer is not empty at the start of each epoch like it is in Thomas's code. To address this we move the new gradient zeroing update to the end of batch 1 to ensure gradients are accumulated correctly.
* Rather than using the per-neuron spike counts for regularisation, Thomas's code reduced these over all batches. This functionality has now been implemented,