### PR TITLE
Increased max delay

### DIFF
--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -195,21 +195,21 @@ class Compiler:
             genn_pop.axonal_delay_steps = delay
         # Otherwise, if maximum delay steps is specified
         elif conn.max_delay_steps is not None:
-            # Check delay fits in 8-bit limit
-            if conn.max_delay_steps > 255:
+            # Check delay fits in 16-bit limit
+            if conn.max_delay_steps > 65535:
                 raise NotImplmentedError(f"Maximum of {conn.max_delay_steps} "
                                          f"delay steps for Connection "
-                                         f"{conn.name} exceeds 255")
+                                         f"{conn.name} exceeds 65535")
             genn_pop.max_dendritic_delay_timesteps = conn.max_delay_steps
         # Otherwise, if delays are specified as an array, 
         # calculate maximum delay steps from array 
         elif is_value_array(delay):
-            # Check max delay fits in 8-bit limit
+            # Check max delay fits in 16-bit limit
             max_delay_steps = np.amax(delay) + 1
-            if max_delay_steps > 255:
+            if max_delay_steps > 65535:
                 raise NotImplmentedError(f"Maximum delay of {max_delay_steps}"
                                          f"for Connection {conn.name} "
-                                         f"exceeds 255")
+                                         f"exceeds 65535")
             
             genn_pop.max_dendritic_delay_timesteps = max_delay_steps
         else:

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -126,7 +126,7 @@ def create_local_var_refs(refs, genn_group):
 def get_delay_type(max_delay):
     if max_delay < 256:
        return "uint8_t"
-    elif max_delay_steps > 65535:
+    elif max_delay > 65535:
         raise NotImplementedError(f"Maximum delay steps exceeds 65535")
     else:
         return "uint16_t"

--- a/ml_genn/ml_genn/compilers/weight_update_models.py
+++ b/ml_genn/ml_genn/compilers/weight_update_models.py
@@ -5,13 +5,6 @@ static_pulse_model = {
         addToPost(g);
         """}
 
-static_pulse_delay_model = {
-    "params": [("g", "scalar"), ("d", "uint16_t")],
-    "pre_spike_syn_code":
-        """
-        addToPostDelay(g, d);
-        """}
-
 signed_static_pulse_model = {
     "params": [("g", "scalar")],
     "pre_spike_syn_code":
@@ -23,13 +16,23 @@ signed_static_pulse_model = {
         addToPost(-g);
         """}
 
-signed_static_pulse_delay_model = {
-    "params": [("g", "scalar"), ("d", "uint16_t")],
-    "pre_spike_syn_code":
-        """
-        addToPostDelay(g, d);
-        """,
-    "pre_event_syn_code":
-        """
-        addToPostDelay(g, -d);
-        """}
+
+def get_static_pulse_delay_model(delay_type):
+    return {"params": [("g", "scalar"), 
+                       ("d", delay_type)],
+            "pre_spike_syn_code":
+                """
+                addToPostDelay(g, d);
+                """}
+
+def get_signed_static_pulse_delay_model(delay_type):
+    return {"params": [("g", "scalar"), 
+                       ("d", delay_type)],
+            "pre_spike_syn_code":
+                """
+                addToPostDelay(g, d);
+                """,
+            "pre_event_syn_code":
+                """
+                addToPostDelay(g, -d);
+                """}

--- a/ml_genn/ml_genn/compilers/weight_update_models.py
+++ b/ml_genn/ml_genn/compilers/weight_update_models.py
@@ -6,7 +6,7 @@ static_pulse_model = {
         """}
 
 static_pulse_delay_model = {
-    "params": [("g", "scalar"), ("d", "uint8_t")],
+    "params": [("g", "scalar"), ("d", "uint16_t")],
     "pre_spike_syn_code":
         """
         addToPostDelay(g, d);
@@ -24,7 +24,7 @@ signed_static_pulse_model = {
         """}
 
 signed_static_pulse_delay_model = {
-    "params": [("g", "scalar"), ("d", "uint8_t")],
+    "params": [("g", "scalar"), ("d", "uint16_t")],
     "pre_spike_syn_code":
         """
         addToPostDelay(g, d);


### PR DESCRIPTION
Heterogeneous delays were previously always stored in ``uint8_t``, limiting them to a maximum of 255 timesteps. @mbalazs98 code this is based on _always_ used ``uint16_t`` which is wasteful.

This PR implements automatic switching to ``uint16_t`` if maximum delay is >= 256

Fixes #113 