### PR TITLE
add the timestep as an argument to the compilers in latency_mnist.py

### DIFF
--- a/examples/event_prop/latency_mnist.py
+++ b/examples/event_prop/latency_mnist.py
@@ -53,7 +53,7 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE,
+                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE, dt=DT,
                                  kernel_profiling=KERNEL_PROFILING)
     compiled_net = compiler.compile(network)
 
@@ -86,7 +86,7 @@ else:
 
     compiler = InferenceCompiler(evaluate_timesteps=max_example_timesteps,
                                  reset_in_syn_between_batches=True,
-                                 batch_size=BATCH_SIZE)
+                                 batch_size=BATCH_SIZE, dt=DT)
     compiled_net = compiler.compile(network)
 
     with compiled_net:


### PR DESCRIPTION
Previously the dt parameter was not passed to the compilers, meaning that they assumed dt == 0.1 even if the rest of the script worked with a different value set by DT.