### PR TITLE
Delay fixes

### DIFF
--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -131,18 +131,21 @@ def get_delay_type(max_delay):
     else:
         return "uint16_t"
 
-def _get_conn_max_delay(conn, delay):
-    # if maximum delay steps is specified
+def get_conn_max_delay(conn, delay):
+    # If maximum delay steps is specified
     if conn.max_delay_steps is not None:
         return 1 + conn.max_delay_steps
-    # Otherwise, if delays are specified as an array, 
-    # calculate maximum delay steps from array 
+    # Otherwise, if delay is constant
+    elif is_value_constant(delay):
+        return 1 + delay
+    # Otherwise, if delays are specified as an array,
+    # calculate maximum delay steps from array
     elif is_value_array(delay):
-        return 1 + np.rint(np.amax(delay)).astype(int)
+        return 1 + np.amax(delay)
     else:
         raise RuntimeError(f"Maximum delay associated with Connection "
-                           f"{conn.name} cannot be determined "
-                           f"automatically, please set max_delay_steps")
+                          f"{conn.name} cannot be determined "
+                          f"automatically, please set max_delay_steps")
 
 class SupportedMatrixType:
     def __init__(self, supported: List[int]):
@@ -218,7 +221,7 @@ class Compiler:
         # Otherwise
         else:
             # Get maximum delay
-            max_delay_steps = _get_conn_max_delay(conn, delay)
+            max_delay_steps = get_conn_max_delay(conn, delay)
 
             # Check delay fits in 16-bit limit
             if max_delay_steps > 65535:
@@ -281,7 +284,7 @@ class Compiler:
         if het_delay:
             # Get delay type to use for this connection
             delay_type = get_delay_type(
-                _get_conn_max_delay(connection, connect_snippet.delay))
+                get_conn_max_delay(connection, connect_snippet.delay))
 
             # If delays are specified as array, round
             # **NOTE** this is to prevent floating point delays e.g. those

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -134,11 +134,11 @@ def get_delay_type(max_delay):
 def _get_conn_max_delay(conn, delay):
     # if maximum delay steps is specified
     if conn.max_delay_steps is not None:
-        return conn.max_delay_steps
+        return 1 + conn.max_delay_steps
     # Otherwise, if delays are specified as an array, 
     # calculate maximum delay steps from array 
     elif is_value_array(delay):
-        return np.rint(np.amax(delay)).astype(int) + 1
+        return 1 + np.rint(np.amax(delay)).astype(int)
     else:
         raise RuntimeError(f"Maximum delay associated with Connection "
                            f"{conn.name} cannot be determined "

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -282,7 +282,12 @@ class Compiler:
             # Get delay type to use for this connection
             delay_type = get_delay_type(
                 _get_conn_max_delay(connection, connect_snippet.delay))
-            param_vals["d"] = connect_snippet.delay
+
+            # Use rounded heterogeneous delay for parameter value
+            # **NOTE** this is to handle floating point delays e.g. obtained
+            # by Eventprop training being truncated at inference-time
+            param_vals["d"] = np.round(connect_snippet.delay)
+
 
         # If source neuron model defines a negative threshold condition
         src_pop = connection.source()

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -283,10 +283,13 @@ class Compiler:
             delay_type = get_delay_type(
                 _get_conn_max_delay(connection, connect_snippet.delay))
 
-            # Use rounded heterogeneous delay for parameter value
-            # **NOTE** this is to handle floating point delays e.g. obtained
-            # by Eventprop training being truncated at inference-time
-            param_vals["d"] = np.round(connect_snippet.delay)
+            # If delays are specified as array, round
+            # **NOTE** this is to prevent floating point delays e.g. those
+            # obtained by Eventprop training being truncated later
+            if is_value_array(connect_snippet.delay):
+                param_vals["d"] = np.round(connect_snippet.delay)
+            else:
+                param_vals["d"] = connect_snippet.delay
 
 
         # If source neuron model defines a negative threshold condition

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -144,8 +144,8 @@ def get_conn_max_delay(conn, delay):
         return 1 + np.round(np.amax(delay)).astype(int)
     else:
         raise RuntimeError(f"Maximum delay associated with Connection "
-                          f"{conn.name} cannot be determined "
-                          f"automatically, please set max_delay_steps")
+                           f"{conn.name} cannot be determined "
+                           f"automatically, please set max_delay_steps")
 
 class SupportedMatrixType:
     def __init__(self, supported: List[int]):

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -137,11 +137,11 @@ def get_conn_max_delay(conn, delay):
         return 1 + conn.max_delay_steps
     # Otherwise, if delay is constant
     elif is_value_constant(delay):
-        return 1 + delay
+        return 1 + round(delay)
     # Otherwise, if delays are specified as an array,
     # calculate maximum delay steps from array
     elif is_value_array(delay):
-        return 1 + np.amax(delay)
+        return 1 + np.round(np.amax(delay)).astype(int)
     else:
         raise RuntimeError(f"Maximum delay associated with Connection "
                           f"{conn.name} cannot be determined "

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -267,14 +267,14 @@ def _get_tau_syn(pop):
 def _get_conn_max_delay(conn, delay):
     # If maximum delay steps is specified
     if conn.max_delay_steps is not None:
-        return conn.max_delay_steps
+        return 1 + conn.max_delay_steps
     # Otherwise, if delay is constant
     elif is_value_constant(delay):
         return 1 + delay
     # Otherwise, if delays are specified as an array,
     # calculate maximum delay steps from array
     elif is_value_array(delay):
-        return np.amax(delay) + 1
+        return 1 + np.amax(delay)
     else:
         raise RuntimeError(f"Maximum delay associated with Connection "
                           f"{conn.name} cannot be determined "

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -30,7 +30,8 @@ from ..utils.snippet import ConnectivitySnippet
 
 from copy import deepcopy
 from pygenn import create_egp_ref, create_var_ref, create_wu_var_ref
-from .compiler import create_reset_custom_update, get_delay_type
+from .compiler import (create_reset_custom_update, get_conn_max_delay,
+                       get_delay_type)
 from ..utils.module import get_object, get_object_mapping
 from ..utils.network import get_underlying_conn, get_underlying_pop
 from ..utils.value import is_value_array, is_value_constant
@@ -263,22 +264,6 @@ def _get_tau_syn(pop):
                                       "different time constants")
     assert tau_syn is not None
     return tau_syn
-
-def _get_conn_max_delay(conn, delay):
-    # If maximum delay steps is specified
-    if conn.max_delay_steps is not None:
-        return 1 + conn.max_delay_steps
-    # Otherwise, if delay is constant
-    elif is_value_constant(delay):
-        return 1 + delay
-    # Otherwise, if delays are specified as an array,
-    # calculate maximum delay steps from array
-    elif is_value_array(delay):
-        return 1 + np.amax(delay)
-    else:
-        raise RuntimeError(f"Maximum delay associated with Connection "
-                          f"{conn.name} cannot be determined "
-                          f"automatically, please set max_delay_steps")
 
 
 class CompileState:
@@ -576,7 +561,7 @@ class EventPropCompiler(Compiler):
     def apply_delay(self, genn_pop, conn: Connection,
                     delay, compile_state):
         # Get max delay
-        max_delay_steps = _get_conn_max_delay(conn, delay)
+        max_delay_steps = get_conn_max_delay(conn, delay)
         
         # If maximum delay steps is within 16-bit limit, set max delay steps
         if max_delay_steps > 65535:
@@ -1176,7 +1161,7 @@ class EventPropCompiler(Compiler):
 
         # Get delay type to use for this connection
         delay_type = get_delay_type(
-            _get_conn_max_delay(conn, connect_snippet.delay))
+            get_conn_max_delay(conn, connect_snippet.delay))
 
         # If this is some form of trainable connectivity
         if connect_snippet.trainable:

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1245,7 +1245,13 @@ class EventPropCompiler(Compiler):
         # If connection has non-learnable delay, set parameter value
         # **NOTE** delay is a state variable for learnable connections
         if not has_learnable_delay and has_delay:
-            wum.param_vals["d"] = connect_snippet.delay
+            # If delays are specified as array, round
+            # **NOTE** this is to prevent floating point delays e.g. those
+            # obtained by Eventprop training being truncated later
+            if is_value_array(connect_snippet.delay):
+                wum.param_vals["d"] = np.round(connect_snippet.delay)
+            else:
+                wum.param_vals["d"] = connect_snippet.delay
 
         # If source neuron isn't an input neuron
         source_neuron = conn.source().neuron


### PR DESCRIPTION
This fixes two nasty issues with delays:

* When learning delays using Eventprop, the synapse variables are ``float`` but get rounded to integer in the CUDA kernels to use as delays. However, when loading these checkpoints into an inference model, delay synapse variables are ``uint8_t`` or ``uint16_t``. Like C++, numpy truncates rather than rounds in this situation which reduces accuracy. Where arrays of delays are used, we now manually round them
* ``SynapseGroup.max_dendritic_delay_timesteps`` needs to always be 1 more than the largest actual delay value. When creating connections with ``max_delay_steps`` set manually,  ``_get_conn_max_delay`` did not take this into account

Additionally, ``EventPropCompiler`` and the ``Compiler`` base class had their own copies of ``_get_conn_max_delay`` which I have de-duplicated

Fixes #129