### PR TITLE
New regularisation scheme - more minimal but also seems to work better

### DIFF
--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1327,7 +1327,7 @@ class EventPropCompiler(Compiler):
                 drive = sympy.Symbol("drive_p" if output else "RevISyn")
                 # add l^- - l^+ jump for neurons with regularisation
                 if regularise:
-                    drive += ((self.dt * self.example_timesteps)-sympy.Symbol("t"))*sympy.Symbol("drive_reg")
+                    drive += sympy.Symbol("drive_reg")/((self.dt * self.example_timesteps)-sympy.Symbol("t"))
                 jump = a_exp + b[a_sym] * (ex2 + drive)
             else:
                 jump = a_exp

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1327,7 +1327,10 @@ class EventPropCompiler(Compiler):
                 drive = sympy.Symbol("drive_p" if output else "RevISyn")
                 # add l^- - l^+ jump for neurons with regularisation
                 if regularise:
-                    drive += sympy.Symbol("drive_reg")/((self.dt * self.example_timesteps)-sympy.Symbol("t"))
+                    # scaling factor is made so that jumps lead to an area of size 1
+                    # to be added to the integral of the "invisible trace variable"
+                    # underlying the regularisation loss
+                    drive += sympy.Symbol("drive_reg")/((self.dt * self.example_timesteps)-sympy.Symbol("t")) 
                 jump = a_exp + b[a_sym] * (ex2 + drive)
             else:
                 jump = a_exp


### PR DESCRIPTION
Changed regularisation to a scheme where there are only jumps in an "invisible" regularisation

variable at spike times. This has the effect that there is no forward dynamics to calculate and no backwards dynamics; regularisation enters through l^- - l^+ terms into lambda jumps of the adjoint variables of all variables contributing to the threshold condition. The scheme appears to work well with a simple shd script.

@neworderofjamie, please check whether you see any remnants of the A_reg scheme that I might have failed to remove.