### PR TITLE
Sub step ode solver

### DIFF
--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -6,6 +6,7 @@ import sympy
 from collections import defaultdict, namedtuple
 from pygenn import CustomUpdateVarAccess, GeNNModel, VarAccess, VarAccessMode
 
+from string import Template
 from typing import List, Optional, Union
 from .compiled_network import CompiledNetwork
 from .. import Connection, Population, Network
@@ -250,11 +251,13 @@ class Compiler:
         """
         if isinstance(model, AutoNeuronModel):
             # Build GeNNCode model
+            dynamics_code = solve_ode(model.dx_dt, self.solver,model.sub_steps)
+
             genn_model = {
                 "vars": model.get_vars("scalar"),
                 "params": model.get_params("scalar"),
                 "sim_code":
-                    solve_ode(model.dx_dt, self.solver),
+                    dynamics_code,
                 "threshold_condition_code":
                     model.get_threshold_condition_code(),
                 "reset_code":

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -173,13 +173,11 @@ class Compiler:
     def __init__(self, supported_matrix_type: List[int], dt: float = 1.0,
                  batch_size: int = 1, rng_seed: int = 0,
                  kernel_profiling: bool = False,
-                 solver: str = "exponential_euler",
                  communicator: Communicator = None, **genn_kwargs):
         self.dt = dt
         self.full_batch_size = batch_size
         self.rng_seed = rng_seed
         self.kernel_profiling = kernel_profiling
-        self.solver = solver
         self.supported_matrix_type = SupportedMatrixType(supported_matrix_type)
         self.communicator = communicator
         self.genn_kwargs = genn_kwargs
@@ -250,7 +248,7 @@ class Compiler:
         """
         if isinstance(model, AutoNeuronModel):
             # Build GeNNCode model
-            dynamics_code = solve_ode(model.dx_dt, self.solver,model.sub_steps)
+            dynamics_code = solve_ode(model.dx_dt, model.solver, model.sub_steps)
 
             genn_model = {
                 "vars": model.get_vars("scalar"),
@@ -300,7 +298,7 @@ class Compiler:
                     f"""
                     {model.get_jump_code()}
                     injectCurrent({model.get_inject_current_code()});
-                    {solve_ode(model.dx_dt, self.solver)}
+                    {solve_ode(model.dx_dt, model.solver)}
                     """}
 
             return SynapseModel(genn_model, copy(model.param_vals),

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -298,7 +298,7 @@ class Compiler:
                     f"""
                     {model.get_jump_code()}
                     injectCurrent({model.get_inject_current_code()});
-                    {solve_ode(model.dx_dt, model.solver)}
+                    {solve_ode(model.dx_dt, model.solver, model.sub_steps)}
                     """}
 
             return SynapseModel(genn_model, copy(model.param_vals),

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -527,7 +527,6 @@ class EventPropCompiler(Compiler):
                  ttfs_alpha: float = 0.01, softmax_temperature: float = 1.0,
                  batch_size: int = 1, rng_seed: int = 0,
                  kernel_profiling: bool = False,
-                 solver: str = "exponential_euler",
                  communicator: Communicator = None,
                  delay_optimiser=None,
                  delay_learn_conns: Sequence = [],
@@ -538,7 +537,7 @@ class EventPropCompiler(Compiler):
                                   SynapseMatrixType.SPARSE]
         super(EventPropCompiler, self).__init__(supported_matrix_types, dt,
                                                 batch_size, rng_seed,
-                                                kernel_profiling, solver,
+                                                kernel_profiling,
                                                 communicator,
                                                 **genn_kwargs)
         self.example_timesteps = example_timesteps
@@ -685,7 +684,7 @@ class EventPropCompiler(Compiler):
         genn_model.prepend_sim_code(
             f"""
             // Backward pass
-            {solve_ode(dl_dt, self.solver)}
+            {solve_ode(dl_dt, model.solver)}
             """)
 
         # Add reset logic to reset adjoint state variables 
@@ -1526,7 +1525,7 @@ class EventPropCompiler(Compiler):
                                   for v in saved_vars_spike)
 
             # Solve ODE and generate dynamics code
-            dynamics_code += solve_ode(dl_dt, self.solver, model.sub_steps)
+            dynamics_code += solve_ode(dl_dt, model.solver, model.sub_steps)
             dynamics_code = Template(dynamics_code).substitute(
                 {s: f"tsRing{s}[tsRingOffset + tsRingReadOffset]" for s in saved_vars_timestep})
 
@@ -1612,7 +1611,7 @@ class EventPropCompiler(Compiler):
                                         for v in saved_vars_timestep)
 
         # Prepend continous adjoint system update
-        dynamics_code = solve_ode(dl_dt, self.solver, model.sub_steps)
+        dynamics_code = solve_ode(dl_dt, model.solver, model.sub_steps)
         dynamics_code = Template(dynamics_code).substitute(
             {s: f"tsRing{s}[tsRingOffset + tsRingReadOffset]" for s in saved_vars_timestep})
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -684,7 +684,7 @@ class EventPropCompiler(Compiler):
         genn_model.prepend_sim_code(
             f"""
             // Backward pass
-            {solve_ode(dl_dt, model.solver)}
+            {solve_ode(dl_dt, model.solver, model.sub_steps)}
             """)
 
         # Add reset logic to reset adjoint state variables 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1526,9 +1526,10 @@ class EventPropCompiler(Compiler):
                                   for v in saved_vars_spike)
 
             # Solve ODE and generate dynamics code
-            dynamics_code += solve_ode(dl_dt, self.solver)
+            dynamics_code += solve_ode(dl_dt, self.solver, model.sub_steps)
             dynamics_code = Template(dynamics_code).substitute(
                 {s: f"tsRing{s}[tsRingOffset + tsRingReadOffset]" for s in saved_vars_timestep})
+
             dynamics_code = f"""
                 {read_pointer_code}
                 {dynamics_code}
@@ -1611,7 +1612,7 @@ class EventPropCompiler(Compiler):
                                         for v in saved_vars_timestep)
 
         # Prepend continous adjoint system update
-        dynamics_code = solve_ode(dl_dt, self.solver)
+        dynamics_code = solve_ode(dl_dt, self.solver, model.sub_steps)
         dynamics_code = Template(dynamics_code).substitute(
             {s: f"tsRing{s}[tsRingOffset + tsRingReadOffset]" for s in saved_vars_timestep})
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1555,6 +1555,8 @@ class EventPropCompiler(Compiler):
                 strict_check=(neuron_reset_strict_check
                                 if self.strict_buffer_checking
                                 else "")))
+        #for x, code in genn_model.model.items():
+        #    print(f"{x}: {code}")
         return genn_model
         
     def _build_out_neuron_model(self, pop: Population, 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1555,8 +1555,6 @@ class EventPropCompiler(Compiler):
                 strict_check=(neuron_reset_strict_check
                                 if self.strict_buffer_checking
                                 else "")))
-        #for x, code in genn_model.model.items():
-        #    print(f"{x}: {code}")
         return genn_model
         
     def _build_out_neuron_model(self, pop: Population, 

--- a/ml_genn/ml_genn/compilers/inference_compiler.py
+++ b/ml_genn/ml_genn/compilers/inference_compiler.py
@@ -366,7 +366,6 @@ class InferenceCompiler(Compiler):
     def __init__(self, evaluate_timesteps: int, dt: float = 1.0,
                  batch_size: int = 1, rng_seed: int = 0,
                  kernel_profiling: bool = False,
-                 solver: str = "exponential_euler",
                  prefer_in_memory_connect=True, 
                  reset_time_between_batches=True,
                  reset_vars_between_batches=True,
@@ -389,7 +388,7 @@ class InferenceCompiler(Compiler):
                                      SynapseMatrixType.DENSE]
         super(InferenceCompiler, self).__init__(supported_matrix_type, dt,
                                                 batch_size, rng_seed,
-                                                kernel_profiling, solver,
+                                                kernel_profiling,
                                                 communicator,
                                                 **genn_kwargs)
         self.evaluate_timesteps = evaluate_timesteps

--- a/ml_genn/ml_genn/neurons/user_neuron.py
+++ b/ml_genn/ml_genn/neurons/user_neuron.py
@@ -29,6 +29,7 @@ class UserNeuron(Neuron):
                  threshold: Optional[str] = None,
                  param_vals: MutableMapping[str, InitValue] = {},
                  var_vals: MutableMapping[str, InitValue] = {},
+                 sub_steps: int = 1,
                  readout=None, **kwargs):
         super(UserNeuron, self).__init__(readout, **kwargs)
 
@@ -37,10 +38,11 @@ class UserNeuron(Neuron):
         self.threshold = threshold
         self.param_vals = param_vals
         self.var_vals = var_vals
+        self.sub_steps = sub_steps
 
     def get_model(self, population: Population, dt: float,
                   batch_size: int) -> Union[AutoNeuronModel, NeuronModel]:
         return AutoNeuronModel({"vars": copy(self.vars), 
                                 "threshold": self.threshold},
                                self.output_var_name, self.param_vals,
-                               self.var_vals)
+                               self.var_vals,self.sub_steps)

--- a/ml_genn/ml_genn/neurons/user_neuron.py
+++ b/ml_genn/ml_genn/neurons/user_neuron.py
@@ -29,6 +29,7 @@ class UserNeuron(Neuron):
                  threshold: Optional[str] = None,
                  param_vals: MutableMapping[str, InitValue] = {},
                  var_vals: MutableMapping[str, InitValue] = {},
+                 solver: str = "exponential_euler",
                  sub_steps: int = 1,
                  readout=None, **kwargs):
         super(UserNeuron, self).__init__(readout, **kwargs)
@@ -38,6 +39,7 @@ class UserNeuron(Neuron):
         self.threshold = threshold
         self.param_vals = param_vals
         self.var_vals = var_vals
+        self.solver = solver
         self.sub_steps = sub_steps
 
     def get_model(self, population: Population, dt: float,
@@ -45,4 +47,4 @@ class UserNeuron(Neuron):
         return AutoNeuronModel({"vars": copy(self.vars), 
                                 "threshold": self.threshold},
                                self.output_var_name, self.param_vals,
-                               self.var_vals, self.sub_steps)
+                               self.var_vals, self.solver, self.sub_steps)

--- a/ml_genn/ml_genn/synapses/user_synapse.py
+++ b/ml_genn/ml_genn/synapses/user_synapse.py
@@ -24,16 +24,18 @@ class UserSynapse(Synapse):
 
     def __init__(self, vars: Variable, inject_current: str,
                  param_vals: MutableMapping[str, InitValue] = {},
-                 var_vals: MutableMapping[str, InitValue] = {}):
+                 var_vals: MutableMapping[str, InitValue] = {},
+                 solver: str = "exponential_euler"):
         super(UserSynapse, self).__init__()
 
         self.vars = vars
         self.inject_current = inject_current
         self.param_vals = param_vals
         self.var_vals = var_vals
+        self.solver = solver
 
     def get_model(self, connection: Connection, dt: float,
                   batch_size: int) -> Union[AutoSynapseModel, SynapseModel]:
         return AutoSynapseModel({"vars": copy(self.vars), 
                                  "inject_current": self.inject_current},
-                                self.param_vals, self.var_vals)
+                                self.param_vals, self.var_vals, self.solver)

--- a/ml_genn/ml_genn/synapses/user_synapse.py
+++ b/ml_genn/ml_genn/synapses/user_synapse.py
@@ -25,7 +25,8 @@ class UserSynapse(Synapse):
     def __init__(self, vars: Variable, inject_current: str,
                  param_vals: MutableMapping[str, InitValue] = {},
                  var_vals: MutableMapping[str, InitValue] = {},
-                 solver: str = "exponential_euler"):
+                 solver: str = "exponential_euler",
+                 sub_steps: int = 1):
         super(UserSynapse, self).__init__()
 
         self.vars = vars
@@ -33,9 +34,11 @@ class UserSynapse(Synapse):
         self.param_vals = param_vals
         self.var_vals = var_vals
         self.solver = solver
+        self.sub_steps = sub_steps
 
     def get_model(self, connection: Connection, dt: float,
                   batch_size: int) -> Union[AutoSynapseModel, SynapseModel]:
         return AutoSynapseModel({"vars": copy(self.vars), 
                                  "inject_current": self.inject_current},
-                                self.param_vals, self.var_vals, self.solver)
+                                self.param_vals, self.var_vals, self.solver,
+                                self.sub_steps)

--- a/ml_genn/ml_genn/utils/auto_model.py
+++ b/ml_genn/ml_genn/utils/auto_model.py
@@ -15,12 +15,14 @@ class AutoModel:
     def __init__(self, model: MutableMapping[str, Any],
                  param_vals: Optional[MutableMapping[str, Value]] = None,
                  var_vals: Optional[MutableMapping[str, Value]] = None,
-                 solver: str = "exponential_euler"):
+                 solver: str = "exponential_euler",
+                 sub_steps: int = 1):
         self.model = model
 
         self.param_vals = param_vals or {}
         self.var_vals = var_vals or {}
         self.solver = solver
+        self.sub_steps = sub_steps
 
         # If model has any variables
         if "vars" in self.model:
@@ -65,7 +67,7 @@ class AutoNeuronModel(AutoModel):
                  var_vals: Optional[MutableMapping[str, Value]] = None,
                  solver: str = "exponential_euler",
                  sub_steps: int = 1):
-        super(AutoNeuronModel, self).__init__(model, param_vals, var_vals, solver)
+        super(AutoNeuronModel, self).__init__(model, param_vals, var_vals, solver, sub_steps)
 
         self.output_var_name = output_var_name
         
@@ -73,8 +75,6 @@ class AutoNeuronModel(AutoModel):
             self.threshold = sympy.parse_expr(self.model["threshold"])
         else:
             self.threshold = 0
-
-        self.sub_steps = sub_steps
 
     # **TODO** property
     def get_threshold_condition_code(self):
@@ -100,8 +100,9 @@ class AutoSynapseModel(AutoModel):
     def __init__(self, model: MutableMapping[str, Any],
                  param_vals: Optional[MutableMapping[str, Value]] = None,
                  var_vals: Optional[MutableMapping[str, Value]] = None,
-                 solver: str = "exponential_euler"):
-        super(AutoSynapseModel, self).__init__(model, param_vals, var_vals, solver)
+                 solver: str = "exponential_euler",
+                 sub_steps: int = 1):
+        super(AutoSynapseModel, self).__init__(model, param_vals, var_vals, solver, sub_steps)
 
         if "inject_current" in self.model:
             self.inject_current = sympy.parse_expr(

--- a/ml_genn/ml_genn/utils/auto_model.py
+++ b/ml_genn/ml_genn/utils/auto_model.py
@@ -14,11 +14,13 @@ Variables = MutableMapping[str, Tuple[Optional[str], Optional[str]]]
 class AutoModel:
     def __init__(self, model: MutableMapping[str, Any],
                  param_vals: Optional[MutableMapping[str, Value]] = None,
-                 var_vals: Optional[MutableMapping[str, Value]] = None):
+                 var_vals: Optional[MutableMapping[str, Value]] = None,
+                 solver: str = "exponential_euler"):
         self.model = model
 
         self.param_vals = param_vals or {}
         self.var_vals = var_vals or {}
+        self.solver = solver
 
         # If model has any variables
         if "vars" in self.model:
@@ -61,8 +63,9 @@ class AutoNeuronModel(AutoModel):
     def __init__(self, model: MutableMapping[str, Any], output_var_name: str,
                  param_vals: Optional[MutableMapping[str, Value]] = None,
                  var_vals: Optional[MutableMapping[str, Value]] = None,
+                 solver: str = "exponential_euler",
                  sub_steps: int = 1):
-        super(AutoNeuronModel, self).__init__(model, param_vals, var_vals)
+        super(AutoNeuronModel, self).__init__(model, param_vals, var_vals, solver)
 
         self.output_var_name = output_var_name
         
@@ -96,8 +99,9 @@ class AutoNeuronModel(AutoModel):
 class AutoSynapseModel(AutoModel):
     def __init__(self, model: MutableMapping[str, Any],
                  param_vals: Optional[MutableMapping[str, Value]] = None,
-                 var_vals: Optional[MutableMapping[str, Value]] = None):
-        super(AutoSynapseModel, self).__init__(model, param_vals, var_vals)
+                 var_vals: Optional[MutableMapping[str, Value]] = None,
+                 solver: str = "exponential_euler"):
+        super(AutoSynapseModel, self).__init__(model, param_vals, var_vals, solver)
 
         if "inject_current" in self.model:
             self.inject_current = sympy.parse_expr(

--- a/ml_genn/ml_genn/utils/auto_model.py
+++ b/ml_genn/ml_genn/utils/auto_model.py
@@ -60,7 +60,8 @@ class AutoModel:
 class AutoNeuronModel(AutoModel):
     def __init__(self, model: MutableMapping[str, Any], output_var_name: str,
                  param_vals: Optional[MutableMapping[str, Value]] = None,
-                 var_vals: Optional[MutableMapping[str, Value]] = None):
+                 var_vals: Optional[MutableMapping[str, Value]] = None,
+                 sub_steps: int = 1):
         super(AutoNeuronModel, self).__init__(model, param_vals, var_vals)
 
         self.output_var_name = output_var_name
@@ -69,6 +70,8 @@ class AutoNeuronModel(AutoModel):
             self.threshold = sympy.parse_expr(self.model["threshold"])
         else:
             self.threshold = 0
+
+        self.sub_steps = sub_steps
 
     # **TODO** property
     def get_threshold_condition_code(self):
@@ -157,4 +160,3 @@ class AutoSynapseModel(AutoModel):
                                                model.get("vars", {}).keys(),
                                                param_vals, var_vals)
         return AutoSynapseModel(model, param_vals, var_vals)
-        

--- a/ml_genn/ml_genn/utils/auto_model.py
+++ b/ml_genn/ml_genn/utils/auto_model.py
@@ -90,11 +90,13 @@ class AutoNeuronModel(AutoModel):
     
     @staticmethod
     def from_val_descriptors(model, output_var_name: str,inst, 
-                             param_vals={}, var_vals={}):
+                             param_vals={}, var_vals={},
+                             solver: str = "exponential_euler",
+                             sub_steps: int = 1):
         param_vals, var_vals = get_auto_values(inst, 
                                                model.get("vars", {}).keys(),
                                                param_vals, var_vals)
-        return AutoNeuronModel(model, output_var_name, param_vals, var_vals)
+        return AutoNeuronModel(model, output_var_name, param_vals, var_vals, solver, sub_steps)
         
 class AutoSynapseModel(AutoModel):
     def __init__(self, model: MutableMapping[str, Any],
@@ -160,8 +162,10 @@ class AutoSynapseModel(AutoModel):
 
     @staticmethod
     def from_val_descriptors(model, inst, 
-                             param_vals={}, var_vals={}):
+                             param_vals={}, var_vals={},
+                             solver: str = "exponential_euler",
+                             sub_steps: int = 1):
         param_vals, var_vals = get_auto_values(inst, 
                                                model.get("vars", {}).keys(),
                                                param_vals, var_vals)
-        return AutoSynapseModel(model, param_vals, var_vals)
+        return AutoSynapseModel(model, param_vals, var_vals, solver, sub_steps)

--- a/ml_genn/ml_genn/utils/auto_tools.py
+++ b/ml_genn/ml_genn/utils/auto_tools.py
@@ -61,7 +61,7 @@ def _get_conditionally_linear_system(dx_dt):
     return coefficients
 
 
-def _exponential_euler(dx_dt):
+def _exponential_euler(dx_dt, sub_steps):
     # Try whether the equations are conditionally linear
     try:
         system = _get_conditionally_linear_system(dx_dt)

--- a/ml_genn/ml_genn/utils/auto_tools.py
+++ b/ml_genn/ml_genn/utils/auto_tools.py
@@ -131,5 +131,4 @@ def solve_ode(dx_dt, solver, sub_steps: int = 1):
             f"EventProp compiler doesn't support "
             f"{solver} solver")
     code = "\n".join(clines)
-    print(code)
     return code


### PR DESCRIPTION
I have implemented a functionality that allows defining a number of integration sub-steps to take per timestep for models with stiff ODEs. The sub_step argument is defined per userneuron/ autoneuron type rather than globally for a compiler because one may well use sub-steps for one neuron model in some neuron group and not for neurons in another neuron group.