### PR TITLE
Param to update weights instead of save new copy

### DIFF
--- a/ml_genn/ml_genn/callbacks/checkpoint.py
+++ b/ml_genn/ml_genn/callbacks/checkpoint.py
@@ -12,9 +12,10 @@ class Checkpoint(Callback):
         epoch_interval: After how many epochs should checkpoints be saved?
     """
     def __init__(self, serialiser: Union[Serialiser, str] ="numpy",
-                 epoch_interval: int = 1):
+                 epoch_interval: int = 1, only_best: bool = False):
         self.serialiser = serialiser
         self.epoch_interval = epoch_interval
+        self.only_best = only_best
 
     def set_params(self, compiled_network, **kwargs):
         # Extract compiled network
@@ -23,4 +24,7 @@ class Checkpoint(Callback):
     def on_epoch_end(self, epoch, metrics):
         # If we should checkpoint this epoch
         if (epoch % self.epoch_interval) == 0:
-            self._compiled_network.save((epoch,), self.serialiser)
+            if self.only_best:
+                self._compiled_network.save((0,), self.serialiser)
+            else:
+                self._compiled_network.save((epoch,), self.serialiser)


### PR DESCRIPTION
If only_best is set to true in the Checkpoint init the saved parameters are updated instead of saving a new copy.