### PR TITLE
Individual optimisers

### DIFF
--- a/examples/event_prop/latency_mnist.py
+++ b/examples/event_prop/latency_mnist.py
@@ -51,9 +51,9 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE, dt=DT,
+                                 batch_size=BATCH_SIZE, dt=DT,
                                  kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(1e-2)}})
 
     with compiled_net:
         visualise_examples = [0, 32, 64, 96]

--- a/examples/event_prop/latency_mnist_augment.py
+++ b/examples/event_prop/latency_mnist_augment.py
@@ -14,7 +14,6 @@ from ml_genn.synapses import Exponential
 from time import perf_counter
 from ml_genn.utils.data import linear_latency_encode_data
 
-from ml_genn.compilers.event_prop_compiler import default_params
 
 NUM_INPUT = 784
 NUM_HIDDEN = 128
@@ -32,7 +31,7 @@ labels = mnist.train_labels() if TRAIN else mnist.test_labels()
 images = mnist.train_images() if TRAIN else mnist.test_images()
 
 serialiser = Numpy("latency_mnist_augment_checkpoints")
-network = SequentialNetwork(default_params)
+network = SequentialNetwork()
 with network:
     # Populations
     input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * NUM_INPUT),
@@ -40,8 +39,7 @@ with network:
     initial_hidden_weight = Normal(mean=0.078, sd=0.045)
     connectivity = (Dense(initial_hidden_weight) if SPARSITY == 1.0 
                     else FixedProbability(SPARSITY, initial_hidden_weight))
-    hidden = Layer(connectivity, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                                    tau_refrac=None),
+    hidden = Layer(connectivity, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0),
                    NUM_HIDDEN, Exponential(5.0))
     output = Layer(Dense(Normal(mean=0.2, sd=0.37)),
                    LeakyIntegrate(tau_mem=20.0, readout="avg_var"),
@@ -51,9 +49,8 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE,
-                                 kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network)
+                                 batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(1e-2)}})
 
     with compiled_net:
         # Evaluate model on numpy dataset

--- a/examples/event_prop/latency_mnist_conv.py
+++ b/examples/event_prop/latency_mnist_conv.py
@@ -16,8 +16,6 @@ from time import perf_counter
 from ml_genn.utils.data import (calc_latest_spike_time, calc_max_spikes,
                                 linear_latency_encode_data)
 
-from ml_genn.compilers.event_prop_compiler import default_params
-
 NUM_INPUT = 784
 NUM_HIDDEN = 128
 NUM_OUTPUT = 10
@@ -35,21 +33,19 @@ spikes = linear_latency_encode_data(
     EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
 
 serialiser = Numpy("latency_mnist_checkpoints")
-network = SequentialNetwork(default_params)
+network = SequentialNetwork()
 with network:
     # Populations
     input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * calc_max_spikes(spikes)),
                                   (28, 28, 1), name="input")
     initial_hidden1_weight = Normal(mean=0.078, sd=0.045)
     hidden1 = Layer(Conv2D(initial_hidden1_weight, 16, 3, True),
-                    LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                       tau_refrac=Nonee),
+                    LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0),
                   synapse=Exponential(5.0), name="hidden1")
     initial_hidden2_weight = Normal(mean=0.078, sd=0.045)
     connectivity2 = (Dense(initial_hidden2_weight) if SPARSITY == 1.0 
                      else FixedProbability(SPARSITY, initial_hidden2_weight))
-    hidden2 = Layer(connectivity2, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                                      tau_refrac=None),
+    hidden2 = Layer(connectivity2, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0),
                     NUM_HIDDEN, Exponential(5.0), name="hidden2")
     output = Layer(Dense(Normal(mean=0.2, sd=0.37)),
                    LeakyIntegrate(tau_mem=20.0, readout="avg_var"),
@@ -59,9 +55,8 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE,
-                                 kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network)
+                                 batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(1e-2)}})
 
     with compiled_net:
         visualise_examples = [0, 32, 64, 96]

--- a/examples/event_prop/latency_mnist_mpi.py
+++ b/examples/event_prop/latency_mnist_mpi.py
@@ -15,7 +15,6 @@ from ml_genn.synapses import Exponential
 from time import perf_counter
 from ml_genn.utils.data import linear_latency_encode_data
 
-from ml_genn.compilers.event_prop_compiler import default_params
 from pygenn.genn_wrapper.CUDABackend import DeviceSelect_MANUAL
 
 NUM_INPUT = 784
@@ -42,7 +41,7 @@ else:
 spikes = linear_latency_encode_data(images, EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
 
 serialiser = Numpy("latency_mnist_mpi_checkpoints")
-network = SequentialNetwork(default_params)
+network = SequentialNetwork()
 with network:
     # Populations
     input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * NUM_INPUT),
@@ -50,8 +49,7 @@ with network:
     initial_hidden_weight = Normal(mean=0.078, sd=0.045)
     connectivity = (Dense(initial_hidden_weight) if SPARSITY == 1.0 
                     else FixedProbability(SPARSITY, initial_hidden_weight))
-    hidden = Layer(connectivity, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                                    tau_refrac=None),
+    hidden = Layer(connectivity, LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0),
                    NUM_HIDDEN, Exponential(5.0))
     output = Layer(Dense(Normal(mean=0.2, sd=0.37)),
                    LeakyIntegrate(tau_mem=20.0, readout="avg_var"),
@@ -61,12 +59,11 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE,
-                                 kernel_profiling=KERNEL_PROFILING,
+                                 batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING,
                                  communicator=communicator,
                                  selectGPUByDeviceID=True,
                                  deviceSelectMethod=DeviceSelect_MANUAL)
-    compiled_net = compiler.compile(network)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(1e-2)}})
 
     with compiled_net:
         # Evaluate model on numpy dataset

--- a/examples/event_prop/latency_mnist_user.py
+++ b/examples/event_prop/latency_mnist_user.py
@@ -64,9 +64,9 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE, dt=DT,
+                                 batch_size=BATCH_SIZE, dt=DT,
                                  kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(1e-2)}})
 
     with compiled_net:
         visualise_examples = [0, 32, 64, 96]

--- a/examples/event_prop/latency_mnist_user_optim.py
+++ b/examples/event_prop/latency_mnist_user_optim.py
@@ -19,7 +19,7 @@ NUM_INPUT = 784
 NUM_HIDDEN = 128
 NUM_OUTPUT = 10
 BATCH_SIZE = 32
-NUM_EPOCHS = 10
+NUM_EPOCHS = 20
 EXAMPLE_TIME = 30.0
 DT = 1.0
 SPARSITY = 1.0
@@ -67,10 +67,11 @@ if TRAIN:
                                  losses="sparse_categorical_crossentropy",
                                  optimiser=Adam(1e-2), batch_size=BATCH_SIZE, dt=DT,
                                  kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network,optimisers={hidden.connection(): {"weight": Adam(1e-2),
-                                                                              "delay": Adam(1e-3)},
-                                                        output.connection(): {"weight": Adam(1e-2)},
-                                                        hidden.population(): {"tau_mem": Adam(1e-2)}})
+    compiled_net = compiler.compile(network,optimisers={#hidden.connection(): {"weight": Adam(1e-2)},
+                                                        #                      "delay": Adam(1e-3)},
+                                                        #output.connection(): {"weight": Adam(1e-2)},
+                                                        hidden.population(): {"tau_mem": Adam(2e-3)}
+    })
 
     with compiled_net:
         visualise_examples = [0, 32, 64, 96]

--- a/examples/event_prop/latency_mnist_user_optim.py
+++ b/examples/event_prop/latency_mnist_user_optim.py
@@ -1,0 +1,114 @@
+import logging
+import numpy as np
+import mnist
+
+from ml_genn import InputLayer, Layer, SequentialNetwork
+from ml_genn.callbacks import Checkpoint
+from ml_genn.compilers import EventPropCompiler, InferenceCompiler
+from ml_genn.connectivity import Dense, FixedProbability
+from ml_genn.initializers import Normal
+from ml_genn.neurons import UserNeuron, SpikeInput
+from ml_genn.optimisers import Adam
+from ml_genn.serialisers import Numpy
+from ml_genn.synapses import UserSynapse
+
+from time import perf_counter
+from ml_genn.utils.data import linear_latency_encode_data
+
+NUM_INPUT = 784
+NUM_HIDDEN = 128
+NUM_OUTPUT = 10
+BATCH_SIZE = 32
+NUM_EPOCHS = 10
+EXAMPLE_TIME = 30.0
+DT = 1.0
+SPARSITY = 1.0
+TRAIN = True
+KERNEL_PROFILING = True
+
+exp_synapse = UserSynapse(vars={"i": ("-i / tau", "i + weight")},
+                          inject_current="i",
+                          param_vals={"tau": 5.0},
+                          var_vals={"i": 0.0})
+lif_neuron = UserNeuron(vars={"v": ("(-v + Isyn) / tau_mem", "0.0")},
+                        threshold="v - 1.0",
+                        output_var_name="v",
+                        param_vals={"tau_mem": 20.0},
+                        var_vals={"v": 0.0})
+li_neuron = UserNeuron(vars={"v": ("(-v + Isyn) / tau_mem", None)},
+                       output_var_name="v",
+                       param_vals={"tau_mem": 20.0},
+                       var_vals={"v": 0.0},
+                       readout="avg_var")
+
+mnist.datasets_url = "https://storage.googleapis.com/cvdf-datasets/mnist/"
+labels = mnist.train_labels() if TRAIN else mnist.test_labels()
+spikes = linear_latency_encode_data(
+    mnist.train_images() if TRAIN else mnist.test_images(),
+    EXAMPLE_TIME - (2.0 * DT), 2.0 * DT)
+
+serialiser = Numpy("latency_mnist_checkpoints")
+network = SequentialNetwork()
+with network:
+    # Populations
+    input = InputLayer(SpikeInput(max_spikes=BATCH_SIZE * NUM_INPUT),
+                                  NUM_INPUT)
+    initial_hidden_weight = Normal(mean=0.078, sd=0.045)
+    connectivity = Dense(initial_hidden_weight,delay=5) 
+#    connectivity = Dense(initial_hidden_weight) 
+    hidden = Layer(connectivity, lif_neuron, NUM_HIDDEN, exp_synapse, max_delay_steps=10)
+#    hidden = Layer(connectivity, lif_neuron, NUM_HIDDEN, exp_synapse)
+    output = Layer(Dense(Normal(mean=0.2, sd=0.37)), li_neuron,
+                   NUM_OUTPUT, exp_synapse)
+
+max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
+if TRAIN:
+    compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
+                                 losses="sparse_categorical_crossentropy",
+                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE, dt=DT,
+                                 kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network,optimisers={hidden.connection(): {"weight": Adam(1e-2),
+                                                                              "delay": Adam(1e-3)},
+                                                        output.connection(): {"weight": Adam(1e-2)},
+                                                        hidden.population(): {"tau_mem": Adam(1e-2)}})
+
+    with compiled_net:
+        visualise_examples = [0, 32, 64, 96]
+        # Evaluate model on numpy dataset
+        start_time = perf_counter()
+        callbacks = ["batch_progress_bar", Checkpoint(serialiser)]
+        metrics, cb_data  = compiled_net.train({input: spikes},
+                                               {output: labels},
+                                               num_epochs=NUM_EPOCHS, shuffle=True,
+                                               callbacks=callbacks)
+        compiled_net.save_connectivity((NUM_EPOCHS - 1,), serialiser)
+        end_time = perf_counter()
+        print(f"Accuracy = {100 * metrics[output].result}%")
+        print(f"Time = {end_time - start_time}s")
+
+        if KERNEL_PROFILING:
+            print(f"Neuron update time = {compiled_net.genn_model.neuron_update_time}")
+            print(f"Presynaptic update time = {compiled_net.genn_model.presynaptic_update_time}")
+            print(f"Gradient batch reduce time = {compiled_net.genn_model.get_custom_update_time('GradientBatchReduce')}")
+            print(f"Gradient learn time = {compiled_net.genn_model.get_custom_update_time('GradientLearn')}")
+            print(f"Reset time = {compiled_net.genn_model.get_custom_update_time('Reset')}")
+            print(f"Softmax1 time = {compiled_net.genn_model.get_custom_update_time('BatchSoftmax1')}")
+            print(f"Softmax2 time = {compiled_net.genn_model.get_custom_update_time('BatchSoftmax2')}")
+            print(f"Softmax3 time = {compiled_net.genn_model.get_custom_update_time('BatchSoftmax3')}")
+else:
+    # Load network state from final checkpoint
+    network.load((NUM_EPOCHS - 1,), serialiser)
+
+    compiler = InferenceCompiler(evaluate_timesteps=max_example_timesteps,
+                                 reset_in_syn_between_batches=True,
+                                 batch_size=BATCH_SIZE, dt=DT)
+    compiled_net = compiler.compile(network)
+
+    with compiled_net:
+        # Evaluate model on numpy dataset
+        start_time = perf_counter()
+        metrics, _  = compiled_net.evaluate({input: spikes},
+                                            {output: labels})
+        end_time = perf_counter()
+        print(f"Accuracy = {100 * metrics[output].result}%")
+        print(f"Time = {end_time - start_time}s")

--- a/examples/event_prop/latency_mnist_user_optim.py
+++ b/examples/event_prop/latency_mnist_user_optim.py
@@ -65,13 +65,11 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(1e-2), batch_size=BATCH_SIZE, dt=DT,
+                                 batch_size=BATCH_SIZE, dt=DT,
                                  kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network,optimisers={#hidden.connection(): {"weight": Adam(1e-2)},
-                                                        #                      "delay": Adam(1e-3)},
-                                                        #output.connection(): {"weight": Adam(1e-2)},
-                                                        hidden: {"tau_mem": "adam"}
-    })
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"},
+                                                         hidden: {"tau_mem": "adam"}})
+
 
     with compiled_net:
         visualise_examples = [0, 32, 64, 96]

--- a/examples/event_prop/latency_mnist_user_optim.py
+++ b/examples/event_prop/latency_mnist_user_optim.py
@@ -68,7 +68,7 @@ if TRAIN:
                                  batch_size=BATCH_SIZE, dt=DT,
                                  kernel_profiling=KERNEL_PROFILING)
     compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"},
-                                                         hidden: {"tau_mem": "adam"}})
+                                                         hidden: {"tau_mem": Adam(2e-3)}})
 
 
     with compiled_net:

--- a/examples/event_prop/latency_mnist_user_optim.py
+++ b/examples/event_prop/latency_mnist_user_optim.py
@@ -70,7 +70,7 @@ if TRAIN:
     compiled_net = compiler.compile(network,optimisers={#hidden.connection(): {"weight": Adam(1e-2)},
                                                         #                      "delay": Adam(1e-3)},
                                                         #output.connection(): {"weight": Adam(1e-2)},
-                                                        hidden.population(): {"tau_mem": Adam(2e-3)}
+                                                        hidden: {"tau_mem": "adam"}
     })
 
     with compiled_net:

--- a/examples/event_prop/pattern_recognition.py
+++ b/examples/event_prop/pattern_recognition.py
@@ -14,8 +14,6 @@ from ml_genn.optimisers import Adam
 from time import perf_counter
 from ml_genn.utils.data import preprocess_spikes
 
-from ml_genn.compilers.event_prop_compiler import default_params
-
 NUM_INPUT = 20
 NUM_HIDDEN = 256
 NUM_OUTPUT = 3
@@ -74,13 +72,12 @@ in_spikes = preprocess_spikes(in_spike_times.flatten(), in_spike_ids, NUM_INPUT)
 in_spikes = [in_spikes] * NUM_TRIALS
 y_star = [y_star] * NUM_TRIALS
 
-network = Network(default_params)
+network = Network()
 with network:
     # Populations
     input = Population(SpikeInput(max_spikes=len(in_spike_ids)),
                                   NUM_INPUT, record_spikes=True)
-    hidden = Population(LeakyIntegrateFire(v_thresh=0.61, tau_mem=TAU_MEM,
-                                           tau_refrac=None),
+    hidden = Population(LeakyIntegrateFire(v_thresh=0.61, tau_mem=TAU_MEM),
                         NUM_HIDDEN, record_spikes=True)
     output = Population(LeakyIntegrate(tau_mem=TAU_MEM, readout="var"),
                         NUM_OUTPUT)
@@ -91,9 +88,8 @@ with network:
     Connection(hidden, output, Dense(Normal(sd=2.0 / np.sqrt(NUM_HIDDEN))), Exponential(TAU_SYN))
 
 compiler = EventPropCompiler(example_timesteps=1000, losses="mean_square_error",
-                         optimiser=Adam(LR), reg_lambda_upper=1e-8, reg_lambda_lower=1e-8, 
-                                 reg_nu_upper=10, max_spikes=1500)
-compiled_net = compiler.compile(network)
+                             reg_lambda=1e-8, reg_nu_upper=10, max_spikes=1500)
+compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(LR)}})
 
 with compiled_net:
     def alpha_schedule(epoch, alpha):

--- a/examples/event_prop/shd.py
+++ b/examples/event_prop/shd.py
@@ -8,7 +8,6 @@ from ml_genn.compilers import EventPropCompiler, InferenceCompiler
 from ml_genn.connectivity import Dense,FixedProbability
 from ml_genn.initializers import Normal
 from ml_genn.neurons import LeakyIntegrate, LeakyIntegrateFire, SpikeInput
-from ml_genn.optimisers import Adam
 from ml_genn.serialisers import Numpy
 from ml_genn.synapses import Exponential
 from tonic.datasets import SHD
@@ -70,9 +69,8 @@ if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
                                  reg_lambda=1e-10, reg_nu_upper=14, max_spikes=1500, 
-                                 optimiser=Adam(0.001), batch_size=BATCH_SIZE, 
-                                 kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network)
+                                 batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"}})
 
     with compiled_net:
         # Evaluate model on numpy dataset

--- a/examples/event_prop/shd_augment.py
+++ b/examples/event_prop/shd_augment.py
@@ -18,8 +18,6 @@ from time import perf_counter
 from ml_genn.utils.data import (calc_latest_spike_time, calc_max_spikes,
                                 preprocess_tonic_spikes)
 
-from ml_genn.compilers.event_prop_compiler import default_params
-
 NUM_HIDDEN = 256
 BATCH_SIZE = 32
 NUM_EPOCHS = 300
@@ -88,13 +86,12 @@ num_input = int(np.prod(dataset.sensor_size))
 num_output = len(dataset.classes)
 
 serialiser = Numpy("shd_augment_checkpoints")
-network = Network(default_params)
+network = Network()
 with network:
     # Populations
     input = Population(SpikeInput(max_spikes=BATCH_SIZE * max_spikes),
                        num_input)
-    hidden = Population(LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                           tau_refrac=None),
+    hidden = Population(LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,),
                         NUM_HIDDEN)
     output = Population(LeakyIntegrate(tau_mem=20.0, readout="avg_var_exp_weight"),
                         num_output)
@@ -111,11 +108,9 @@ max_example_timesteps = int(np.ceil(latest_spike_time / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 reg_lambda_upper=4e-09, reg_lambda_lower=4e-09, 
-                                 reg_nu_upper=14, max_spikes=1500, 
-                                 optimiser=Adam(0.001), batch_size=BATCH_SIZE, 
-                                 kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network)
+                                 reg_lambda=4e-09, reg_nu_upper=14, max_spikes=1500, 
+                                 batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"}})
 
     with compiled_net:
         # Loop through epochs

--- a/examples/event_prop/shd_delay_shift_blend.py
+++ b/examples/event_prop/shd_delay_shift_blend.py
@@ -15,7 +15,6 @@ from time import perf_counter
 from ml_genn.utils.data import (calc_latest_spike_time, calc_max_spikes,
                                 preprocess_tonic_spikes)
 
-from ml_genn.compilers.event_prop_compiler import default_params
 import copy
 
 NUM_HIDDEN = 256
@@ -153,8 +152,8 @@ for i in idx[7644:]:
 
     spikes_val.append(preprocess_tonic_spikes(delay(events), dataset.ordering,
                                               (dataset.sensor_size[0]*N_DELAY,
-                                              dataset.sensor_size[1],
-                                              dataset.sensor_size[2])))
+                                               dataset.sensor_size[1],
+                                               dataset.sensor_size[2])))
     labels_val.append(label)
 
 max_spikes = max(max_spikes, calc_max_spikes(spikes_val))
@@ -168,9 +167,9 @@ for i in range(len(dataset)):
     events, label = dataset[i]
     events = np.delete(events, np.where(events["t"] >= 1000000))
     spikes_test.append(preprocess_tonic_spikes(delay(events), dataset.ordering,
-                                            (dataset.sensor_size[0]*N_DELAY,
-                                            dataset.sensor_size[1],
-                                            dataset.sensor_size[2])))
+                                               (dataset.sensor_size[0]*N_DELAY,
+                                                dataset.sensor_size[1],
+                                                dataset.sensor_size[2])))
     labels_test.append(label)
 
 max_spikes = max(max_spikes, calc_max_spikes(spikes_test))
@@ -181,13 +180,12 @@ print(f"Max spikes {max_spikes}, latest spike time {latest_spike_time}")
 
 
 serialiser = Numpy("shd_augment_checkpoints")
-network = Network(default_params)
+network = Network()
 with network:
     # Populations
     input = Population(SpikeInput(max_spikes=BATCH_SIZE * max_spikes * N_DELAY),
                        num_input *  N_DELAY)
-    hidden = Population(LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0,
-                                           tau_refrac=None),
+    hidden = Population(LeakyIntegrateFire(v_thresh=1.0, tau_mem=20.0),
                         NUM_HIDDEN, record_spikes=True)
     output = Population(LeakyIntegrate(tau_mem=20.0, readout="avg_var_exp_weight"),
                         num_output)
@@ -203,11 +201,9 @@ with network:
 max_example_timesteps = int(np.ceil(latest_spike_time / DT))
 
 compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
-                                losses="sparse_categorical_crossentropy",
-                                reg_lambda_upper=5e-11, reg_lambda_lower=5e-11,
-                                reg_nu_upper=14, max_spikes=1500,
-                                optimiser=Adam(0.001 * 0.01), batch_size=BATCH_SIZE)
-compiled_net = compiler.compile(network)
+                             losses="sparse_categorical_crossentropy",
+                             reg_lambda=5e-11, reg_nu_upper=14, max_spikes=1500, batch_size=BATCH_SIZE)
+compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(0.001 * 0.01)}})
 best_acc, best_e = 0, 0
 with compiled_net:
     # Loop through epochs

--- a/examples/event_prop/yin_yang.py
+++ b/examples/event_prop/yin_yang.py
@@ -50,10 +50,9 @@ max_example_timesteps = int(np.ceil(EXAMPLE_TIME / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 optimiser=Adam(0.003, 0.9, 0.99), batch_size=BATCH_SIZE,
-                                 softmax_temperature=0.5, ttfs_alpha=0.1, dt=DT,
-                                 kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network)
+                                 batch_size=BATCH_SIZE, softmax_temperature=0.5, 
+                                 ttfs_alpha=0.1, dt=DT, kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(0.003, 0.9, 0.99)}})
 
     with compiled_net:
         def alpha_schedule(epoch, alpha):

--- a/ml_genn/ml_genn/compilers/compiled_training_network.py
+++ b/ml_genn/ml_genn/compilers/compiled_training_network.py
@@ -318,10 +318,9 @@ class CompiledTrainingNetwork(CompiledNetwork):
                               self.communicator)
 
         # Loop through optimisers
-        for o, custom_updates in self.optimisers:
+        for o, c in self.optimisers:
             # Set step on all custom updates
-            for c in custom_updates:
-                o.set_step(c, step)
+            o.set_step(c, step)
 
         # End batch
         callback_list.on_batch_end(batch, metrics)

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -399,6 +399,7 @@ class Compiler:
             out_post_vars.append(("DenDelay", "scalar", 0.0))
 
         # Create reset model
+        print(dir(genn_syn_pop))
         zero_out_post_model = create_reset_custom_update(
             out_post_vars,
             lambda name: (create_out_post_var_ref(genn_syn_pop) 

--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -399,7 +399,6 @@ class Compiler:
             out_post_vars.append(("DenDelay", "scalar", 0.0))
 
         # Create reset model
-        print(dir(genn_syn_pop))
         zero_out_post_model = create_reset_custom_update(
             out_post_vars,
             lambda name: (create_out_post_var_ref(genn_syn_pop) 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1297,7 +1297,7 @@ class EventPropCompiler(Compiler):
         grad_terms = {}
         for p in learn_params:
             sym = sympy.Symbol(p)
-            o = - sum(sympy.diff(expr2, sym) + _get_lmd_sym(sym2)
+            o = - sum(sympy.diff(expr2, sym) * _get_lmd_sym(sym2)
                     for sym2, expr2 in model.dx_dt.items())
             # collect variables they might need to go into a ring buffer:
             o = _template_symbols(

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -265,9 +265,8 @@ def _add_required_parameters(model: AutoModel, genn_model: Model, expression):
 
 
 class CompileState:
-    def __init__(self, losses, readouts, optimisers, backend_name):
-        self.losses = get_object_mapping(losses, readouts,
-                                         Loss, "Loss", default_losses)
+    def __init__(self, network: Network, losses, optimisers, 
+                 supported_matrix_type, backend_name):
         self.backend_name = backend_name
         self._neuron_reset_vars = []
         self._synapse_reset_vars = []
@@ -277,7 +276,76 @@ class CompileState:
         self.feedback_connections = []
         self.update_trial_pops = []
         self.adjoint_limit_pops_vars = []
-        self.optimisers = optimisers
+        self.optimisers = {}
+
+        # Build list of output populations
+        readouts = [p for p in network.populations
+                    if p.neuron.readout is not None]
+
+        # From these, create losses
+        self.losses = get_object_mapping(losses, readouts,
+                                         Loss, "Loss", default_losses)
+
+        # If default optimiser settings for all connections has been provided
+        if "all_connections" in optimisers:
+            # Loop through all connections
+            vars = optimisers["all_connections"]
+            for conn in network.connections:
+                # If connectivity is trainable, create 
+                # optimisers for specified variables
+                connect_snippet = conn.connectivity.get_snippet(
+                    conn, supported_matrix_type)
+                if connect_snippet.trainable:
+                    self.optimisers[conn] = {n: get_object(o, Optimiser, 
+                                                           "Optimiser",
+                                                           default_optimisers)
+                                             for n, o in vars.items()}
+
+        # Loop through optimisers to build pre-processed dictionary
+        # **NOTE** these will override any optimiser configured with shortcuts
+        for k, vars in optimisers.items():
+            # If key is a Connection, Population or InputLayer,
+            # what variables relate to is unambiguous
+            if isinstance(k, (Connection, Population, InputLayer)):
+                # Create optimisers
+                vars = {n: get_object(o, Optimiser, "Optimiser",
+                                      default_optimisers)
+                        for n, o in vars.items()}
+                
+                # If key is InputLayer, de-sugar to population
+                if isinstance(k, InputLayer):
+                    self.optimisers[k.population()] = vars
+                # Otherwise, use key directly
+                else:
+                    self.optimisers[k] = vars
+            # Otherwise, if it's a layer, variable might be related
+            # to connection OR population contained within layer
+            elif isinstance(k, Layer):
+                # Split variable dictionary into connection and
+                # population variables and create optimisers
+                con_vars = {n: get_object(o, Optimiser, "Optimiser",
+                                          default_optimisers)
+                            for n, o in vars.items()
+                            if n == "weight" or n == "delay"}
+                pop_vars = {n: get_object(o, Optimiser, "Optimiser",
+                                          default_optimisers)
+                            for n, o in vars.items()
+                            if n != "weight" and n != "delay"}
+
+                # If any of either type of variable exist, add to
+                # dictionary with appropriately de-sugared key
+                if len(con_vars) > 0:
+                    self.optimisers[k.connection()] = con_vars
+                if len(pop_vars) > 0:
+                    self.optimisers[k.population()] = pop_vars
+    
+            # Otherwise, if key isn't one of the shortcut strings
+            # which have already been processed, give error
+            elif k != "all_connections":
+                raise RuntimeError(f"Invalid key '{k}' used in 'optimisers' "
+                                   f"dictionary. Valid keys are Connection, "
+                                   f"Population, InputLayer or Layer objects "
+                                   f"Or strings such as 'all_connections'")
 
     def add_neuron_reset_vars(self, pop, reset_vars, 
                               reset_event_ring, reset_v_ring):
@@ -571,82 +639,19 @@ class EventPropCompiler(Compiler):
 
     def pre_compile(self, network: Network, 
                     genn_model, **kwargs) -> CompileState:
-        # Build list of output populations
-        readouts = [p for p in network.populations
-                    if p.neuron.readout is not None]
-        
         # Get base dictionary of optimiser. If none is provided, default
         # to training all weights using the adam optimiser with default params
-        base_optimisers = kwargs.get("optimisers", 
-                                     {"all_connections": {"weight": "adam"}})
+        optimisers = kwargs.get("optimisers", 
+                                {"all_connections": {"weight": "adam"}})
 
         # Check dictionary has been provided
-        if not isinstance(base_optimisers, Mapping):
+        if not isinstance(optimisers, Mapping):
             raise RuntimeError("optimisers should be "
                                "specified as a dictionary")
 
-        # If default optimiser settings for all connections has been provided
-        optimisers = {}
-        if "all_connections" in base_optimisers:
-            # Loop through all connections
-            vars = base_optimisers["all_connections"]
-            for conn in network.connections:
-                # If connectivity is trainable, create 
-                # optimisers for specified variables
-                connect_snippet = conn.connectivity.get_snippet(
-                    conn, self.supported_matrix_type)
-                if connect_snippet.trainable:
-                    optimisers[conn] = {n: get_object(o, Optimiser, 
-                                                      "Optimiser",
-                                                      default_optimisers)
-                                        for n, o in vars.items()}
 
-        # Loop through optimisers to build pre-processed dictionary
-        # **NOTE** these will override any optimiser configured with shortcuts
-        for k, vars in base_optimisers.items():
-            # If key is a Connection, Population or InputLayer,
-            # what variables relate to is unambiguous
-            if isinstance(k, (Connection, Population, InputLayer)):
-                # Create optimisers
-                vars = {n: get_object(o, Optimiser, "Optimiser",
-                                      default_optimisers)
-                        for n, o in vars.items()}
-                
-                # If key is InputLayer, de-sugar to population
-                if isinstance(k, InputLayer):
-                    optimisers[k.population()] = vars
-                # Otherwise, use key directly
-                else:
-                    optimisers[k] = vars
-            # Otherwise, if it's a layer, variable might be related
-            # to connection OR population contained within layer
-            elif isinstance(k, Layer):
-                # Split variable dictionary into connection and
-                # population variables and create optimisers
-                con_vars = {n: get_object(o, Optimiser, "Optimiser",
-                                          default_optimisers)
-                            for n, o in vars.items()
-                            if n == "weight" or n == "delay"}
-                pop_vars = {n: get_object(o, Optimiser, "Optimiser",
-                                          default_optimisers)
-                            for n, o in vars.items()
-                            if n != "weight" and n != "delay"}
-
-                # If any of either type of variable exist, add to
-                # dictionary with appropriately de-sugared key
-                if len(con_vars) > 0:
-                    optimisers[k.connection()] = con_vars
-                if len(pop_vars) > 0:
-                    optimisers[k.population()] = pop_vars
-            # Otherwise, if key isn't one of the shortcut strings
-            # which have already been processed, give error
-            elif k != "all_connections":
-                raise RuntimeError(f"Invalid key '{k}' used in 'optimisers' "
-                                   f"dictionary. Valid keys are Connection, "
-                                   f"Population, InputLayer or Layer objects "
-                                   f"Or strings such as 'all_connections'")
-
-        return CompileState(self.losses, readouts, optimisers,
+        return CompileState(network, self.losses, optimisers,
+                            self.supported_matrix_type, 
                             genn_model.backend_name)
 
     def apply_delay(self, genn_pop, conn: Connection,

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1619,8 +1619,7 @@ class EventPropCompiler(Compiler):
             example_timesteps=self.example_timesteps)
 
         # Build adjoint system from model
-        learn_params= [] if pop not in compile_state.optimisers \
-            else compile_state.optimisers[pop]
+        learn_params = compile_state.optimisers.get(pop, {})
         dl_dt, adjoint_jumps, grad_terms, saved_vars_timestep, saved_vars_spike =\
             self._build_adjoint_system(model, learn_params, True, False)
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -271,8 +271,6 @@ class CompileState:
         self.backend_name = backend_name
         self._neuron_reset_vars = []
         self._synapse_reset_vars = []
-        self.checkpoint_connection_vars = []
-        self.checkpoint_population_vars = []
         self.spike_count_populations = []
         self.batch_softmax_populations = []
         self.timestep_softmax_populations = []
@@ -954,9 +952,6 @@ class EventPropCompiler(Compiler):
             # Add weight gradient
             genn_model.add_var("weightGradient", "scalar", 0.0)
 
-            # Add weights to list of checkpoint vars
-            compile_state.checkpoint_connection_vars.append((conn, "weight"))
-
             # If connection is delayed, add delay index calculation
             if has_learnable_delay:
                 genn_model.append_pre_event_syn_code(
@@ -999,10 +994,6 @@ class EventPropCompiler(Compiler):
                 # Add delay gradient
                 genn_model.add_var("delayGradient", "scalar", 0.0)
 
-                # Add delays to list of checkpoint vars
-                compile_state.checkpoint_connection_vars.append(
-                    (conn, "delay"))
-
                 # Add delay calculation
                 logger.debug(f"\tDelay gradient update: {dx_dt_diff_sum}")
                 genn_model.append_pre_event_syn_code(
@@ -1032,45 +1023,51 @@ class EventPropCompiler(Compiler):
         for c in compile_state.feedback_connections:
             connection_populations[c].pre_target_var = "RevISyn"
 
-        # Loop through connections that require optimisers
+        # Loop through connections and populations that require optimisers
         optimisers = []
+        checkpoint_connection_vars = []
+        checkpoint_population_vars = []
         need_zero_gradient_update_group = False
         i = 0
-        for c, optim in compile_state.optimisers.items():
-            if c in connection_populations:
-                genn_pop = connection_populations[c]
-            
+        for k, vars in compile_state.optimisers.items():
+            # If key is a connection
+            if k in connection_populations:
+                # If weight optimisation is required
+                genn_pop = connection_populations[k]
                 gradient_vars = []
-                for var, o in optim.items():
-                    # If weight optimisation is required
-                    if var == "weight":
-                        # Create weight optimiser custom update
-                        # TODO: Should this be more general for any var in wum?
-                        cu_weight = self._create_optimiser_custom_update(
-                            f"Weight{i}", create_wu_var_ref(genn_pop, "weight"),
-                            create_wu_var_ref(genn_pop, "weightGradient"), 
-                            o, genn_model)
-                
-                        # Add custom update to list of optimisers
-                        optimisers.append((deepcopy(o), cu_weight))
-
-                        # Add gradient to list of gradient vars to zero
-                        gradient_vars.append(("weightGradient", "scalar", 0.0))
+                if "weight" in vars:
+                    # Create weight optimiser custom update
+                    cu_weight = self._create_optimiser_custom_update(
+                        f"Weight{i}", create_wu_var_ref(genn_pop, "weight"),
+                        create_wu_var_ref(genn_pop, "weightGradient"), 
+                        vars["weight"], genn_model)
             
-                    # If delay optimiser is required
-                    if var == "delay":
-                        # Create delay optimiser custom update
-                        cu_delay = self._create_optimiser_custom_update(
-                            f"Delay{i}", create_wu_var_ref(genn_pop, "delay"),
-                            create_wu_var_ref(genn_pop, "delayGradient"),
-                            o, genn_model,
-                            (0.0, c.max_delay_steps))
-
-                        # Add custom update to list of optimisers
-                        optimisers.append((deepcopy(o), cu_delay))
+                    # Add custom update to list of optimisers
+                    optimisers.append((deepcopy(vars["weight"]), cu_weight))
+                    
+                    # Add variable to list of those to checkpoint
+                    checkpoint_connection_vars.append((k, "weight"))
+                    
+                    # Add gradient to list of gradient vars to zero
+                    gradient_vars.append(("weightGradient", "scalar", 0.0))
                 
-                        # Add gradient to list of gradient vars to zero
-                        gradient_vars.append(("delayGradient", "scalar", 0.0))
+                # If delay optimiser is required
+                if "delay" in vars:
+                    # Create delay optimiser custom update
+                    cu_delay = self._create_optimiser_custom_update(
+                        f"Delay{i}", create_wu_var_ref(genn_pop, "delay"),
+                        create_wu_var_ref(genn_pop, "delayGradient"),
+                        vars["delay"], genn_model,
+                        (0.0, c.max_delay_steps))
+
+                    # Add custom update to list of optimisers
+                    optimisers.append((deepcopy(vars["delay"]), cu_delay))
+
+                    # Add variable to list of those to checkpoint
+                    checkpoint_connection_vars.append((k, "delay"))
+
+                    # Add gradient to list of gradient vars to zero
+                    gradient_vars.append(("delayGradient", "scalar", 0.0))
 
                 # Create reset model for gradient variables
                 assert len(gradient_vars) > 0
@@ -1082,24 +1079,24 @@ class EventPropCompiler(Compiler):
                 self.add_custom_update(genn_model, zero_grad_model,
                                        "ZeroGradient", f"CUZeroConnGradient{i}")
                 need_zero_gradient_update_group = True
-                i = i+1
-
-        # Loop through populations that require optimisers
-        i = 0
-        for c, optim in compile_state.optimisers.items():
-            if c in neuron_populations:
-                genn_pop = neuron_populations[c]
-                for p, o in optim.items():
+                i += 1
+            # Otherwise if key is a population
+            elif k in neuron_populations:
+                genn_pop = neuron_populations[k]
+                for n, o in vars.items():
                     # Create parameter optimiser custom update
                     cu_param = self._create_optimiser_custom_update(
-                        f"{p}{i}", create_var_ref(genn_pop, p),
-                            create_var_ref(genn_pop, f"{p}Gradient"),
+                        f"{n}{i}", create_var_ref(genn_pop, n),
+                            create_var_ref(genn_pop, f"{n}Gradient"),
                             o, genn_model)
 
                     # Add custom update to list of optimisers
                     optimisers.append((deepcopy(o), cu_param))
+                    checkpoint_population_vars.append((k, n))
 
-                i = i+1
+                i += 1
+            else:
+                assert False
 
         # Add per-batch softmax custom updates for each population that requires them
         for p, i, o in compile_state.batch_softmax_populations:
@@ -1192,8 +1189,7 @@ class EventPropCompiler(Compiler):
             self.communicator, compile_state.losses,
             self.example_timesteps, base_train_callbacks,
             base_validate_callbacks, optimisers,
-            compile_state.checkpoint_connection_vars,
-            compile_state.checkpoint_population_vars, True)
+            checkpoint_connection_vars, checkpoint_population_vars, True)
 
     def _add_softmax_buffer_custom_updates(self, genn_model, genn_pop, 
                                            input_var_name: str):

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1028,7 +1028,6 @@ class EventPropCompiler(Compiler):
         for c, optim in compile_state.optimisers.items():
             if c in neuron_populations:
                 genn_pop = neuron_populations[c]
-                #gradient_vars = []
                 for p, o in optim.items():
                     # Create parameter optimiser custom update
                     cu_param = self._create_optimiser_custom_update(

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -9,8 +9,7 @@ from pygenn import (CustomUpdateVarAccess, VarAccess, VarAccessMode,
 
 from .compiler import Compiler
 from .compiled_training_network import CompiledTrainingNetwork
-from .. import (AllConnections, AllPopulations, Connection, 
-                InputLayer, Layer, Population, Network)
+from .. import Connection, InputLayer, Layer, Population, Network
 from ..callbacks import (BatchProgressBar, Callback, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnEpochEnd,
                          CustomUpdateOnTimestepEnd)
@@ -270,7 +269,6 @@ class CompileState:
         self.losses = get_object_mapping(losses, readouts,
                                          Loss, "Loss", default_losses)
         self.backend_name = backend_name
-        self._optimiser_connections = []
         self._neuron_reset_vars = []
         self._synapse_reset_vars = []
         self.checkpoint_connection_vars = []
@@ -282,9 +280,6 @@ class CompileState:
         self.update_trial_pops = []
         self.adjoint_limit_pops_vars = []
         self.optimisers = optimisers
-
-    def add_optimiser_connection(self, conn, weight: bool, delay: bool):
-        self._optimiser_connections.append((conn, weight, delay))
 
     def add_neuron_reset_vars(self, pop, reset_vars, 
                               reset_event_ring, reset_v_ring):
@@ -361,10 +356,6 @@ class CompileState:
             # Add custom update
             compiler.add_custom_update(genn_model, model, 
                                        "Reset", f"CUResetSynapse{i}")
-    
-    @property
-    def optimiser_connections(self):
-        return self._optimiser_connections
 
     @property
     def is_reset_custom_update_required(self):
@@ -480,9 +471,6 @@ class EventPropCompiler(Compiler):
         losses:                     Either a dictionary mapping loss functions
                                     to output populations or a single loss
                                     function to apply to all outputs
-        optimiser:                  global optimiser to be used for learnable
-                                    parameters - only used if not overriden
-                                    during compile()
         reg_lambda:                 Regularisation strength
         reg_nu_upper:               Target number of hidden neuron
                                     spikes used for regularisation
@@ -540,6 +528,10 @@ class EventPropCompiler(Compiler):
                                                 kernel_profiling,
                                                 communicator,
                                                 **genn_kwargs)
+        if "optimiser" in genn_kwargs:
+            warn("The 'param_names' parameter has been renamed to 'params' "
+                "and will be removed in future", FutureWarning)
+    
         self.example_timesteps = example_timesteps
         self.losses = losses
         self.reg_lambda = reg_lambda
@@ -550,9 +542,7 @@ class EventPropCompiler(Compiler):
         self.per_timestep_loss = per_timestep_loss
         self.ttfs_alpha = ttfs_alpha
         self.softmax_temperature = softmax_temperature
-        self._optimiser = get_object(optimiser, Optimiser, "Optimiser",
-                                     default_optimisers)
-
+        
         # If legacy upper and lower regularisation strength is specified
         reg_lambda_upper = genn_kwargs.get("reg_lambda_upper")
         reg_lambda_lower = genn_kwargs.get("reg_lambda_lower")
@@ -576,61 +566,75 @@ class EventPropCompiler(Compiler):
         readouts = [p for p in network.populations
                     if p.neuron.readout is not None]
         
-        # use explicit dictionary of optimisers if provided
-        if "optimisers" in kwargs:
-            if not isinstance(kwargs["optimisers"], Mapping):
-                raise RuntimeError("Optimisers should be "
-                                   "specified as a dictionary")
+        # Get base dictionary of optimiser. If none is provided, default
+        # to training all weights using the adam optimiser with default params
+        base_optimisers = kwargs.get("optimisers", 
+                                     {"all_connections": {"weight", "adam"}})
 
-            # Loop through optimisers to build pre-processed dictionary
-            optimisers = {}
-            for k, vars in kwargs["optimisers"].items():
-                # If key is a Connection, Population or InputLayer,
-                # what variables relate to is unambiguous
-                if isinstance(k, (Connection, Population, InputLayer)):
-                    # Create optimisers
-                    vars = {n: get_object(o, Optimiser, "Optimiser",
-                                          default_optimisers)
-                            for n, o in vars.items()}
-                    
-                    # If key is InputLayer, de-sugar to population
-                    if isinstance(k, InputLayer):
-                        optimisers[k.population()] = vars
-                    # Otherwise, use key directly
-                    else:
-                        optimisers[k] = vars
-                # Otherwise, if it's a layer, variable might be related
-                # to connection OR population contained within layer
-                elif isinstance(k, Layer):
-                    # Split variable dictionary into connection and
-                    # population variables and create optimisers
-                    con_vars = {n: get_object(o, Optimiser, "Optimiser",
-                                              default_optimisers)
-                                for n, o in vars.items()
-                                if n == "weight" or n == "delay"}
-                    pop_vars = {n: get_object(o, Optimiser, "Optimiser",
-                                              default_optimisers)
-                                for n, o in vars.items()
-                                if n != "weight" and n != "delay"}
+        # Check dictionary has been provided
+        if not isinstance(base_optimisers, Mapping):
+            raise RuntimeError("optimisers should be "
+                               "specified as a dictionary")
 
-                    # If any of either type of variable exist, add to
-                    # dictionary with appropriately de-sugared key
-                    if len(con_vars) > 0:
-                        optimisers[k.connection()] = con_vars
-                    if len(pop_vars) > 0:
-                        optimisers[k.population()] = pop_vars
-                # **TODO** sentinel
-                else:
-                    raise RuntimeError("Optimisers dictionary "
-                                       "specified as a dictionary")
-        else:   # learn weights with compiler's default optimiser
-            optimisers = {}
+        # If default optimiser settings for all connections has been provided
+        optimisers = {}
+        if "all_connections" in base_optimisers:
+            # Loop through all connections
+            vars = base_optimisers["all_connections"]
             for conn in network.connections:
+                # If connectivity is trainable, create 
+                # optimisers for specified variables
                 connect_snippet = conn.connectivity.get_snippet(
                     conn, self.supported_matrix_type)
                 if connect_snippet.trainable:
-                    optim[conn] = {"weight": self._optimiser}
+                    optimisers[conn] = {n: get_object(o, Optimiser, 
+                                                      "Optimiser",
+                                                      default_optimisers)
+                                        for n, o in vars.items()}
 
+        # Loop through optimisers to build pre-processed dictionary
+        # **NOTE** these will override any optimiser configured with shortcuts
+        for k, vars in base_optimisers.items():
+            # If key is a Connection, Population or InputLayer,
+            # what variables relate to is unambiguous
+            if isinstance(k, (Connection, Population, InputLayer)):
+                # Create optimisers
+                vars = {n: get_object(o, Optimiser, "Optimiser",
+                                      default_optimisers)
+                        for n, o in vars.items()}
+                
+                # If key is InputLayer, de-sugar to population
+                if isinstance(k, InputLayer):
+                    optimisers[k.population()] = vars
+                # Otherwise, use key directly
+                else:
+                    optimisers[k] = vars
+            # Otherwise, if it's a layer, variable might be related
+            # to connection OR population contained within layer
+            elif isinstance(k, Layer):
+                # Split variable dictionary into connection and
+                # population variables and create optimisers
+                con_vars = {n: get_object(o, Optimiser, "Optimiser",
+                                          default_optimisers)
+                            for n, o in vars.items()
+                            if n == "weight" or n == "delay"}
+                pop_vars = {n: get_object(o, Optimiser, "Optimiser",
+                                          default_optimisers)
+                            for n, o in vars.items()
+                            if n != "weight" and n != "delay"}
+
+                # If any of either type of variable exist, add to
+                # dictionary with appropriately de-sugared key
+                if len(con_vars) > 0:
+                    optimisers[k.connection()] = con_vars
+                if len(pop_vars) > 0:
+                    optimisers[k.population()] = pop_vars
+            # Otherwise, if key isn't one of the shortcut strings
+            # which have already been processed, give error
+            elif k != "all_connections":
+                raise RuntimeError("Optimisers dictionary "
+                                   "specified as a dictionary")
+        print(optimisers)
         return CompileState(self.losses, readouts, optimisers,
                             genn_model.backend_name)
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1026,7 +1026,7 @@ class EventPropCompiler(Compiler):
         for c, optim in compile_state.optimisers.items():
             if c in neuron_populations:
                 genn_pop = neuron_populations[c]
-                gradient_vars = []
+                #gradient_vars = []
                 for p, o in optim.items():
                     # Create parameter optimiser custom update
                     cu_param = self._create_optimiser_custom_update(
@@ -1039,16 +1039,16 @@ class EventPropCompiler(Compiler):
 
                     # Add gradient to list of gradient vars to zero
                     # JAMIE: is this necessary or am I duplicating reset_vars
-                    gradient_vars.append((f"{p}Gradient", "scalar", 0.0))
+                    #gradient_vars.append((f"{p}Gradient", "scalar", 0.0))
                 # Create reset model for gradient variables
-                assert len(gradient_vars) > 0
-                zero_grad_model = create_reset_custom_update(
-                    gradient_vars,
-                    lambda name: create_var_ref(genn_pop, name))
+                #assert len(gradient_vars) > 0
+                #zero_grad_model = create_reset_custom_update(
+                #    gradient_vars,
+                #    lambda name: create_var_ref(genn_pop, name))
 
                 # Add custom update
-                self.add_custom_update(genn_model, zero_grad_model,
-                                       "ZeroGradient", f"CUZeroPopGradient{i}")
+                #self.add_custom_update(genn_model, zero_grad_model,
+                #                       "ZeroGradient", f"CUZeroPopGradient{i}")
                 i = i+1
 
         # Add per-batch softmax custom updates for each population that requires them
@@ -1294,7 +1294,7 @@ class EventPropCompiler(Compiler):
         grad_terms = {}
         for p in learn_params:
             sym = sympy.Symbol(p)
-            o = sum(sympy.diff(expr2, sym) + _get_lmd_sym(sym2)
+            o = - sum(sympy.diff(expr2, sym) + _get_lmd_sym(sym2)
                     for sym2, expr2 in model.dx_dt.items())
             # collect variables they might need to go into a ring buffer:
             o = _template_symbols(

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -577,7 +577,7 @@ class EventPropCompiler(Compiler):
         compile_state = CompileState(self.losses, readouts,
                             genn_model.backend_name)
         # use explicit dictionary of optimisers if provided
-        if "optimisers" in kwargs.keys():
+        if "optimisers" in kwargs:
             compile_state.optimisers = kwargs["optimisers"]
         else:   # learn weights with compiler's default optimiser
             optim = {}

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -508,7 +508,7 @@ class EventPropCompiler(Compiler):
         
     """
 
-    def __init__(self, example_timesteps: int, losses, optimiser="adam",
+    def __init__(self, example_timesteps: int, losses,
                  reg_lambda: float = 0.0, reg_nu_upper: float = 0.0,
                  grad_limit: float = 100.0,
                  max_spikes: int = 500, 
@@ -528,9 +528,15 @@ class EventPropCompiler(Compiler):
                                                 kernel_profiling,
                                                 communicator,
                                                 **genn_kwargs)
-        if "optimiser" in genn_kwargs:
-            warn("The 'param_names' parameter has been renamed to 'params' "
-                "and will be removed in future", FutureWarning)
+        if "optimiser" in genn_kwargs or "delay_optimiser" in genn_kwargs:
+            raise RuntimeError("The 'optimiser' and 'delay_optimiser' "
+                               "parameters have been removed from the "
+                               "EventPropCompiler constructor. Optimisers "
+                               "are now specified by passing a 'optimisers' "
+                               "keyword argument to the ``compile`` method "
+                               "e.g. optimisers={\"all_connections\": "
+                               "{\"weight\": \"adam\"} to optimise all "
+                               "weights with the adam optimiser")
     
         self.example_timesteps = example_timesteps
         self.losses = losses
@@ -632,8 +638,10 @@ class EventPropCompiler(Compiler):
             # Otherwise, if key isn't one of the shortcut strings
             # which have already been processed, give error
             elif k != "all_connections":
-                raise RuntimeError("Optimisers dictionary "
-                                   "specified as a dictionary")
+                raise RuntimeError(f"Invalid key '{k}' used in 'optimisers' "
+                                   f"dictionary. Valid keys are Connection, "
+                                   f"Population, InputLayer or Layer objects "
+                                   f"Or strings such as 'all_connections'")
 
         return CompileState(self.losses, readouts, optimisers,
                             genn_model.backend_name)

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1457,8 +1457,7 @@ class EventPropCompiler(Compiler):
                     "neurons defined in terms of AutoNeuronModel")
             
             # Build adjoint system from model
-            learn_params= [] if pop not in compile_state.optimisers \
-                else compile_state.optimisers[pop]
+            learn_params = compile_state.optimisers.get(pop, {})
             dl_dt, adjoint_jumps, grad_terms, saved_vars_timestep, saved_vars_spike =\
                 self._build_adjoint_system(model, learn_params, False, self.reg_lambda != 0.0)
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -709,8 +709,8 @@ class EventPropCompiler(Compiler):
         has_delay = (not is_value_constant(connect_snippet.delay)
                      or connect_snippet.delay > 0)
         # Does this connection have learnable delays
-        has_learnable_delay = conn in compile_state.optimisers.keys()\
-            and "delay" in compile_state.optimisers[conn].keys() 
+        has_learnable_delay = (conn in compile_state.optimisers
+                               and "delay" in compile_state.optimisers[conn])
 
         # Get name of variable containing integer delay for indexing
         int_delay_name = "delayInt" if has_learnable_delay else "delay"

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -974,10 +974,7 @@ class EventPropCompiler(Compiler):
         optimisers = []
         i = 0
         for c, optim in compile_state.optimisers.items():
-            print(c)
-            print(connection_populations)
             if c in connection_populations:
-                print("yes")
                 genn_pop = connection_populations[c]
             
                 gradient_vars = []

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -973,6 +973,7 @@ class EventPropCompiler(Compiler):
 
         # Loop through connections that require optimisers
         optimisers = []
+        need_zero_gradient_update_group = False
         i = 0
         for c, optim in compile_state.optimisers.items():
             if c in connection_populations:
@@ -1019,6 +1020,7 @@ class EventPropCompiler(Compiler):
                 # Add custom update
                 self.add_custom_update(genn_model, zero_grad_model,
                                        "ZeroGradient", f"CUZeroConnGradient{i}")
+                need_zero_gradient_update_group = True
                 i = i+1
 
         # Loop through populations that require optimisers
@@ -1096,8 +1098,9 @@ class EventPropCompiler(Compiler):
                     CustomUpdateOnBatchEndNotFirst("GradientBatchReduce"))
             base_train_callbacks.append(
                 CustomUpdateOnBatchEndNotFirst("GradientLearn"))
-            base_train_callbacks.append(
-                CustomUpdateOnFirstBatchEnd("ZeroGradient"))
+            if need_zero_gradient_update_group:
+                base_train_callbacks.append(
+                    CustomUpdateOnFirstBatchEnd("ZeroGradient"))
 
         # Add callbacks to set Trial extra global parameter 
         # on populations which require it

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -262,6 +262,7 @@ def _add_required_parameters(model: AutoModel, genn_model: Model, expression):
         if (expression.has(sympy.Symbol(n)) and not genn_model.has_param(n)):
             genn_model.add_param(n, "scalar", v)
 
+            
 class CompileState:
     def __init__(self, losses, readouts, backend_name):
         self.losses = get_object_mapping(losses, readouts,
@@ -278,6 +279,7 @@ class CompileState:
         self.feedback_connections = []
         self.update_trial_pops = []
         self.adjoint_limit_pops_vars = []
+        self.optimisers = {}
 
     def add_optimiser_connection(self, conn, weight: bool, delay: bool):
         self._optimiser_connections.append((conn, weight, delay))
@@ -476,7 +478,9 @@ class EventPropCompiler(Compiler):
         losses:                     Either a dictionary mapping loss functions
                                     to output populations or a single loss
                                     function to apply to all outputs
-        optimiser:                  Optimiser to use when applying weights
+        optimiser:                  global optimiser to be used for learnable
+                                    parameters - only used if not overriden
+                                    during compile()
         reg_lambda:                 Regularisation strength
         reg_nu_upper:               Target number of hidden neuron
                                     spikes used for regularisation
@@ -511,10 +515,6 @@ class EventPropCompiler(Compiler):
         communicator:               Communicator used for inter-process
                                     communications when training across
                                     multiple GPUs.
-        delay_optimiser:            Optimiser to use when applying delays. If 
-                                    None, ``optimiser`` will be used for delays
-        delay_learn_conns:          Connection for which delays should be 
-                                    learned as well as weight
         
     """
 
@@ -528,8 +528,6 @@ class EventPropCompiler(Compiler):
                  batch_size: int = 1, rng_seed: int = 0,
                  kernel_profiling: bool = False,
                  communicator: Communicator = None,
-                 delay_optimiser=None,
-                 delay_learn_conns: Sequence = [],
                  **genn_kwargs):
         supported_matrix_types = [SynapseMatrixType.TOEPLITZ,
                                   SynapseMatrixType.PROCEDURAL_KERNELG,
@@ -552,11 +550,6 @@ class EventPropCompiler(Compiler):
         self.softmax_temperature = softmax_temperature
         self._optimiser = get_object(optimiser, Optimiser, "Optimiser",
                                      default_optimisers)
-        self._delay_optimiser = get_object(
-            optimiser if delay_optimiser is None else delay_optimiser, 
-            Optimiser, "Optimiser", default_optimisers)
-        self.delay_learn_conns = set(get_underlying_conn(c)
-                                     for c in delay_learn_conns)
 
         # If legacy upper and lower regularisation strength is specified
         reg_lambda_upper = genn_kwargs.get("reg_lambda_upper")
@@ -580,9 +573,21 @@ class EventPropCompiler(Compiler):
         # Build list of output populations
         readouts = [p for p in network.populations
                     if p.neuron.readout is not None]
-
-        return CompileState(self.losses, readouts,
+        compile_state = CompileState(self.losses, readouts,
                             genn_model.backend_name)
+        # use explicit dictionary of optimisers if provided
+        if "optimisers" in kwargs.keys():
+            compile_state.optimisers = kwargs["optimisers"]
+        else:   # learn weights with compiler's default optimiser
+            optim = {}
+            for conn in network.connections:
+                connect_snippet =\
+                conn.connectivity.get_snippet(conn,
+                                              self.supported_matrix_type)
+                if connect_snippet.trainable:
+                    optim[conn] = {"weight": self._optimiser}
+            compile_state.optimisers = optim
+        return compile_state
 
     def apply_delay(self, genn_pop, conn: Connection,
                     delay, compile_state):
@@ -704,16 +709,13 @@ class EventPropCompiler(Compiler):
                      or connect_snippet.delay > 0)
         
         # Does this connection have learnable delays
-        has_learnable_delay = conn in self.delay_learn_conns
+        has_learnable_delay = conn in compile_state.optimisers.keys()\
+            and "delay" in compile_state.optimisers[conn].keys() 
 
         # Get name of variable containing integer delay for indexing
         int_delay_name = "delayInt" if has_learnable_delay else "delay"
 
-        # Mark which sorts of optimiser connection will require
-        compile_state.add_optimiser_connection(conn, connect_snippet.trainable,
-                                               has_learnable_delay)
-
-        # Get synapse mdeol
+        # Get synapse model
         synapse_model = conn.synapse.get_model(conn, self.dt, self.batch_size)
         assert isinstance(synapse_model, AutoSynapseModel)
     
@@ -749,7 +751,7 @@ class EventPropCompiler(Compiler):
         logger.debug(f"\tSynapse inject_plusm: {inject_plus_m_expr}")
         logger.debug(f"\tSynapse dx_dtplusm: {syn_dx_dt_plus_m}")
         
-        # Get target neuron mdeol
+        # Get target neuron model
         trg_pop = conn.target()
         trg_neuron_model = trg_pop.neuron.get_model(trg_pop, self.dt,
                                                     self.batch_size)
@@ -970,40 +972,48 @@ class EventPropCompiler(Compiler):
             connection_populations[c].pre_target_var = "RevISyn"
 
         # Loop through connections that require optimisers
-        weight_optimiser_cus = []
-        delay_optimiser_cus = []
-        for i, (c, w, d) in enumerate(compile_state.optimiser_connections):
-            genn_pop = connection_populations[c]
+        optimisers = []
+        i = 0
+        for c, optim in compile_state.optimisers.items():
+            print(c)
+            print(connection_populations)
+            if c in connection_populations:
+                print("yes")
+                genn_pop = connection_populations[c]
             
-            # If weight optimisation is required
-            gradient_vars = []
-            if w:
-                # Create weight optimiser custom update
-                cu_weight = self._create_optimiser_custom_update(
-                    f"Weight{i}", create_wu_var_ref(genn_pop, "weight"),
-                    create_wu_var_ref(genn_pop, "weightGradient"), 
-                    self._optimiser, genn_model)
+                gradient_vars = []
+                for var, o in optim.items():
+                    # If weight optimisation is required
+                    if var == "weight":
+                        # Create weight optimiser custom update
+                        # TODO: Should this be more general for any var in wum?
+                        cu_weight = self._create_optimiser_custom_update(
+                            f"Weight{i}", create_wu_var_ref(genn_pop, "weight"),
+                            create_wu_var_ref(genn_pop, "weightGradient"), 
+                            o, genn_model)
                 
-                # Add custom update to list of optimisers
-                weight_optimiser_cus.append(cu_weight)
+                        # Add custom update to list of optimisers
+                        optimisers.append((deepcopy(o), cu_weight))
 
-                # Add gradient to list of gradient vars to zero
-                gradient_vars.append(("weightGradient", "scalar", 0.0))
+                        # Add gradient to list of gradient vars to zero
+                        gradient_vars.append(("weightGradient", "scalar", 0.0))
+                        i = i+1
             
-            # If delay optimiser is required
-            if d:
-                # Create delay optimiser custom update
-                cu_delay = self._create_optimiser_custom_update(
-                    f"Delay{i}", create_wu_var_ref(genn_pop, "delay"),
-                    create_wu_var_ref(genn_pop, "delayGradient"),
-                    self._delay_optimiser, genn_model,
-                    (0.0, c.max_delay_steps))
+                    # If delay optimiser is required
+                    if var == "delay":
+                        # Create delay optimiser custom update
+                        cu_delay = self._create_optimiser_custom_update(
+                            f"Delay{i}", create_wu_var_ref(genn_pop, "delay"),
+                            create_wu_var_ref(genn_pop, "delayGradient"),
+                            o, genn_model,
+                            (0.0, c.max_delay_steps))
 
-                # Add custom update to list of optimisers
-                delay_optimiser_cus.append(cu_delay)
+                        # Add custom update to list of optimisers
+                        optimisers.append((deepcopy(o), cu_delay))
                 
-                # Add gradient to list of gradient vars to zero
-                gradient_vars.append(("delayGradient", "scalar", 0.0))
+                        # Add gradient to list of gradient vars to zero
+                        gradient_vars.append(("delayGradient", "scalar", 0.0))
+                        i = i+1
 
             # Create reset model for gradient variables
             assert len(gradient_vars) > 0
@@ -1054,7 +1064,7 @@ class EventPropCompiler(Compiler):
         # Build list of base callbacks
         base_train_callbacks = []
         base_validate_callbacks = []
-        if len(weight_optimiser_cus) > 0 or len(delay_optimiser_cus) > 0:
+        if len(optimisers) > 0:
             if self.full_batch_size > 1:
                 base_train_callbacks.append(
                     CustomUpdateOnBatchEndNotFirst("GradientBatchReduce"))
@@ -1099,13 +1109,6 @@ class EventPropCompiler(Compiler):
         if compile_state.is_reset_custom_update_required:
             base_train_callbacks.append(CustomUpdateOnBatchBegin("Reset"))
             base_validate_callbacks.append(CustomUpdateOnBatchBegin("Reset"))
-
-        # Build list of optimisers and their custom updates
-        optimisers = []
-        if len(weight_optimiser_cus) > 0:
-            optimisers.append((deepcopy(self._optimiser), weight_optimiser_cus))
-        if len(delay_optimiser_cus) > 0:
-            optimisers.append((deepcopy(self._delay_optimiser), delay_optimiser_cus))
 
         return CompiledTrainingNetwork(
             genn_model, neuron_populations, connection_populations,

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -523,11 +523,7 @@ class EventPropCompiler(Compiler):
                                   SynapseMatrixType.PROCEDURAL_KERNELG,
                                   SynapseMatrixType.DENSE,
                                   SynapseMatrixType.SPARSE]
-        super(EventPropCompiler, self).__init__(supported_matrix_types, dt,
-                                                batch_size, rng_seed,
-                                                kernel_profiling,
-                                                communicator,
-                                                **genn_kwargs)
+        
         if "optimiser" in genn_kwargs or "delay_optimiser" in genn_kwargs:
             raise RuntimeError("The 'optimiser' and 'delay_optimiser' "
                                "parameters have been removed from the "
@@ -537,7 +533,32 @@ class EventPropCompiler(Compiler):
                                "e.g. optimisers={\"all_connections\": "
                                "{\"weight\": \"adam\"} to optimise all "
                                "weights with the adam optimiser")
-    
+        
+        # If legacy upper and lower regularisation strength are specified
+        # **NOTE** needs to be before superclass call so these get removed 
+        # from genn_kwargs as unknown arguments now causes an error
+        reg_lambda_upper = genn_kwargs.pop("reg_lambda_upper", None)
+        reg_lambda_lower = genn_kwargs.pop("reg_lambda_lower", None)
+        if reg_lambda_upper is not None or reg_lambda_lower is not None:
+            # If they match, use as regularisation strength
+            if reg_lambda_upper == reg_lambda_lower:
+                reg_lambda = reg_lambda_upper
+                warn("Seperate 'reg_lambda_upper' and 'reg_lambda_lower' "
+                     "arguments for EventPropCompiler are no longer "
+                     "supported, please use 'reg_lambda'", FutureWarning)
+            # Otherwise, give error
+            else:
+                raise NotImplemented("Seperate 'reg_lambda_upper' and "
+                                     "'reg_lambda_lower' arguments for "
+                                     "EventPropCompiler are no longer "
+                                     "supported, please use 'reg_lambda'")
+
+        super(EventPropCompiler, self).__init__(supported_matrix_types, dt,
+                                                batch_size, rng_seed,
+                                                kernel_profiling,
+                                                communicator,
+                                                **genn_kwargs)
+        
         self.example_timesteps = example_timesteps
         self.losses = losses
         self.reg_lambda = reg_lambda
@@ -549,22 +570,6 @@ class EventPropCompiler(Compiler):
         self.ttfs_alpha = ttfs_alpha
         self.softmax_temperature = softmax_temperature
         
-        # If legacy upper and lower regularisation strength is specified
-        reg_lambda_upper = genn_kwargs.get("reg_lambda_upper")
-        reg_lambda_lower = genn_kwargs.get("reg_lambda_lower")
-        if reg_lambda_upper is not None or reg_lambda_lower is not None:
-            # If they match, use as regularisation strength
-            if reg_lambda_upper == reg_lambda_lower:
-                self.reg_lambda = reg_lambda_upper
-                warn("Seperate 'reg_lambda_upper' and 'reg_lambda_lower' "
-                     "arguments for EventPropCompiler are no longer "
-                     "supported, please use 'reg_lambda'", FutureWarning)
-            # Otherwise, give error
-            else:
-                raise NotImplemented("Seperate 'reg_lambda_upper' and "
-                                     "'reg_lambda_lower' arguments for "
-                                     "EventPropCompiler are no longer "
-                                     "supported, please use 'reg_lambda'")
 
     def pre_compile(self, network: Network, 
                     genn_model, **kwargs) -> CompileState:

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1039,18 +1039,6 @@ class EventPropCompiler(Compiler):
                     # Add custom update to list of optimisers
                     optimisers.append((deepcopy(o), cu_param))
 
-                    # Add gradient to list of gradient vars to zero
-                    # JAMIE: is this necessary or am I duplicating reset_vars
-                    #gradient_vars.append((f"{p}Gradient", "scalar", 0.0))
-                # Create reset model for gradient variables
-                #assert len(gradient_vars) > 0
-                #zero_grad_model = create_reset_custom_update(
-                #    gradient_vars,
-                #    lambda name: create_var_ref(genn_pop, name))
-
-                # Add custom update
-                #self.add_custom_update(genn_model, zero_grad_model,
-                #                       "ZeroGradient", f"CUZeroPopGradient{i}")
                 i = i+1
 
         # Add per-batch softmax custom updates for each population that requires them

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -569,7 +569,7 @@ class EventPropCompiler(Compiler):
         # Get base dictionary of optimiser. If none is provided, default
         # to training all weights using the adam optimiser with default params
         base_optimisers = kwargs.get("optimisers", 
-                                     {"all_connections": {"weight", "adam"}})
+                                     {"all_connections": {"weight": "adam"}})
 
         # Check dictionary has been provided
         if not isinstance(base_optimisers, Mapping):
@@ -634,7 +634,7 @@ class EventPropCompiler(Compiler):
             elif k != "all_connections":
                 raise RuntimeError("Optimisers dictionary "
                                    "specified as a dictionary")
-        print(optimisers)
+
         return CompileState(self.losses, readouts, optimisers,
                             genn_model.backend_name)
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -707,7 +707,6 @@ class EventPropCompiler(Compiler):
         # Does this connection have a delay?
         has_delay = (not is_value_constant(connect_snippet.delay)
                      or connect_snippet.delay > 0)
-        
         # Does this connection have learnable delays
         has_learnable_delay = conn in compile_state.optimisers.keys()\
             and "delay" in compile_state.optimisers[conn].keys() 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -3,13 +3,14 @@ import numpy as np
 import sympy
 
 from string import Template
-from typing import Iterator, Sequence, Union
+from typing import Iterator, Mapping, Sequence, Union
 from pygenn import (CustomUpdateVarAccess, VarAccess, VarAccessMode,
                     SynapseMatrixType, SynapseMatrixWeight)
 
 from .compiler import Compiler
 from .compiled_training_network import CompiledTrainingNetwork
-from .. import Connection, Population, Network
+from .. import (AllConnections, AllPopulations, Connection, 
+                InputLayer, Layer, Population, Network)
 from ..callbacks import (BatchProgressBar, Callback, CustomUpdateOnBatchBegin,
                          CustomUpdateOnBatchEnd, CustomUpdateOnEpochEnd,
                          CustomUpdateOnTimestepEnd)
@@ -263,9 +264,9 @@ def _add_required_parameters(model: AutoModel, genn_model: Model, expression):
         if (expression.has(sympy.Symbol(n)) and not genn_model.has_param(n)):
             genn_model.add_param(n, "scalar", v)
 
-            
+
 class CompileState:
-    def __init__(self, losses, readouts, backend_name):
+    def __init__(self, losses, readouts, optimisers, backend_name):
         self.losses = get_object_mapping(losses, readouts,
                                          Loss, "Loss", default_losses)
         self.backend_name = backend_name
@@ -280,7 +281,7 @@ class CompileState:
         self.feedback_connections = []
         self.update_trial_pops = []
         self.adjoint_limit_pops_vars = []
-        self.optimisers = {}
+        self.optimisers = optimisers
 
     def add_optimiser_connection(self, conn, weight: bool, delay: bool):
         self._optimiser_connections.append((conn, weight, delay))
@@ -574,21 +575,64 @@ class EventPropCompiler(Compiler):
         # Build list of output populations
         readouts = [p for p in network.populations
                     if p.neuron.readout is not None]
-        compile_state = CompileState(self.losses, readouts,
-                            genn_model.backend_name)
+        
         # use explicit dictionary of optimisers if provided
         if "optimisers" in kwargs:
-            compile_state.optimisers = kwargs["optimisers"]
+            if not isinstance(kwargs["optimisers"], Mapping):
+                raise RuntimeError("Optimisers should be "
+                                   "specified as a dictionary")
+
+            # Loop through optimisers to build pre-processed dictionary
+            optimisers = {}
+            for k, vars in kwargs["optimisers"].items():
+                # If key is a Connection, Population or InputLayer,
+                # what variables relate to is unambiguous
+                if isinstance(k, (Connection, Population, InputLayer)):
+                    # Create optimisers
+                    vars = {n: get_object(o, Optimiser, "Optimiser",
+                                          default_optimisers)
+                            for n, o in vars.items()}
+                    
+                    # If key is InputLayer, de-sugar to population
+                    if isinstance(k, InputLayer):
+                        optimisers[k.population()] = vars
+                    # Otherwise, use key directly
+                    else:
+                        optimisers[k] = vars
+                # Otherwise, if it's a layer, variable might be related
+                # to connection OR population contained within layer
+                elif isinstance(k, Layer):
+                    # Split variable dictionary into connection and
+                    # population variables and create optimisers
+                    con_vars = {n: get_object(o, Optimiser, "Optimiser",
+                                              default_optimisers)
+                                for n, o in vars.items()
+                                if n == "weight" or n == "delay"}
+                    pop_vars = {n: get_object(o, Optimiser, "Optimiser",
+                                              default_optimisers)
+                                for n, o in vars.items()
+                                if n != "weight" and n != "delay"}
+
+                    # If any of either type of variable exist, add to
+                    # dictionary with appropriately de-sugared key
+                    if len(con_vars) > 0:
+                        optimisers[k.connection()] = con_vars
+                    if len(pop_vars) > 0:
+                        optimisers[k.population()] = pop_vars
+                # **TODO** sentinel
+                else:
+                    raise RuntimeError("Optimisers dictionary "
+                                       "specified as a dictionary")
         else:   # learn weights with compiler's default optimiser
-            optim = {}
+            optimisers = {}
             for conn in network.connections:
-                connect_snippet =\
-                conn.connectivity.get_snippet(conn,
-                                              self.supported_matrix_type)
+                connect_snippet = conn.connectivity.get_snippet(
+                    conn, self.supported_matrix_type)
                 if connect_snippet.trainable:
                     optim[conn] = {"weight": self._optimiser}
-            compile_state.optimisers = optim
-        return compile_state
+
+        return CompileState(self.losses, readouts, optimisers,
+                            genn_model.backend_name)
 
     def apply_delay(self, genn_pop, conn: Connection,
                     delay, compile_state):

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1863,6 +1863,7 @@ class EventPropCompiler(Compiler):
 
                         genn_model.prepend_sim_code(
                             f"""
+                            const scalar backT = {self.example_timesteps * self.dt} - t - dt;
                             scalar drive = 0.0;
                             if (Trial > 0 && fabs(backT - {out_var_name}MaxTimeBack) < 1e-3*dt) {{
                                 const scalar g = (id == YTrueBack) ? (1.0 - Softmax) : -Softmax;

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -34,6 +34,7 @@ from itertools import chain
 from warnings import warn
 from pygenn import (create_egp_ref, create_psm_var_ref,
                     create_var_ref, create_wu_var_ref)
+from pygenn._genn import WUVarReference
 from .compiler import (create_reset_custom_update, get_delay_type,
                        get_conn_max_delay)
 from ..utils.auto_tools import solve_ode
@@ -993,7 +994,6 @@ class EventPropCompiler(Compiler):
 
                         # Add gradient to list of gradient vars to zero
                         gradient_vars.append(("weightGradient", "scalar", 0.0))
-                        i = i+1
             
                     # If delay optimiser is required
                     if var == "delay":
@@ -1009,17 +1009,47 @@ class EventPropCompiler(Compiler):
                 
                         # Add gradient to list of gradient vars to zero
                         gradient_vars.append(("delayGradient", "scalar", 0.0))
-                        i = i+1
 
-            # Create reset model for gradient variables
-            assert len(gradient_vars) > 0
-            zero_grad_model = create_reset_custom_update(
-                gradient_vars,
-                lambda name: create_wu_var_ref(genn_pop, name))
+                # Create reset model for gradient variables
+                assert len(gradient_vars) > 0
+                zero_grad_model = create_reset_custom_update(
+                    gradient_vars,
+                    lambda name: create_wu_var_ref(genn_pop, name))
 
-            # Add custom update
-            self.add_custom_update(genn_model, zero_grad_model, 
-                                   "ZeroGradient", f"CUZeroConnGradient{i}")
+                # Add custom update
+                self.add_custom_update(genn_model, zero_grad_model,
+                                       "ZeroGradient", f"CUZeroConnGradient{i}")
+                i = i+1
+
+        # Loop through populations that require optimisers
+        i = 0
+        for c, optim in compile_state.optimisers.items():
+            if c in neuron_populations:
+                genn_pop = neuron_populations[c]
+                gradient_vars = []
+                for p, o in optim.items():
+                    # Create parameter optimiser custom update
+                    cu_param = self._create_optimiser_custom_update(
+                        f"{p}{i}", create_var_ref(genn_pop, p),
+                            create_var_ref(genn_pop, f"{p}Gradient"),
+                            o, genn_model)
+
+                    # Add custom update to list of optimisers
+                    optimisers.append((deepcopy(o), cu_param))
+
+                    # Add gradient to list of gradient vars to zero
+                    # JAMIE: is this necessary or am I duplicating reset_vars
+                    gradient_vars.append((f"{p}Gradient", "scalar", 0.0))
+                # Create reset model for gradient variables
+                assert len(gradient_vars) > 0
+                zero_grad_model = create_reset_custom_update(
+                    gradient_vars,
+                    lambda name: create_var_ref(genn_pop, name))
+
+                # Add custom update
+                self.add_custom_update(genn_model, zero_grad_model,
+                                       "ZeroGradient", f"CUZeroPopGradient{i}")
+                i = i+1
 
         # Add per-batch softmax custom updates for each population that requires them
         for p, i, o in compile_state.batch_softmax_populations:
@@ -1199,8 +1229,12 @@ class EventPropCompiler(Compiler):
 
             # Create optimiser model without gradient zeroing
             # logic, connected to reduced gradient
-            reduced_gradient = create_wu_var_ref(genn_reduction,
-                                                 "ReducedGradient")
+            if isinstance(var_ref, WUVarReference):
+                reduced_gradient = create_wu_var_ref(genn_reduction,
+                                                     "ReducedGradient")
+            else:
+                reduced_gradient = create_var_ref(genn_reduction,
+                                                  "ReducedGradient")
             optimiser_model = optimiser.get_model(reduced_gradient, var_ref,
                                                   False, clamp_var)
         # Otherwise
@@ -1231,7 +1265,7 @@ class EventPropCompiler(Compiler):
                 genn_model, reduction_optimiser_model, 
                 "SpikeCountReduce", name)
     
-    def _build_adjoint_system(self, model: AutoNeuronModel,
+    def _build_adjoint_system(self, model: AutoNeuronModel, learn_params,
                               output: bool, regularise: bool):
         logger.debug("\tBuilding adjoint system for AutoNeuronModel:")
         logger.debug(f"\t\tVariables: {model.var_vals.keys()}")
@@ -1253,8 +1287,19 @@ class EventPropCompiler(Compiler):
             o = _template_symbols(
                 o, chain(model.var_vals.keys(), ["Isyn"]), saved_vars_timestep)
             dl_dt[_get_lmd_sym(sym)] = o
-            
+
         logger.debug(f"\t\tAdjoint ODE: {dl_dt}")
+
+        # create expressions for learned neuron parameters
+        grad_terms = {}
+        for p in learn_params:
+            sym = sympy.Symbol(p)
+            o = sum(sympy.diff(expr2, sym) + _get_lmd_sym(sym2)
+                    for sym2, expr2 in model.dx_dt.items())
+            # collect variables they might need to go into a ring buffer:
+            o = _template_symbols(
+                o, chain(model.var_vals.keys(), ["Isyn"]), saved_vars_timestep)
+            grad_terms[sym] = o
 
         # Substitute jumps into ODEs to get post-jump dynamics "\dot{x}^+"
         dx_dt_plus_n = {}
@@ -1352,7 +1397,7 @@ class EventPropCompiler(Compiler):
         logger.debug(f"\t\tSaved variables per timestep: {saved_vars_timestep}")
         logger.debug(f"\t\tSaved variables per spike: {saved_vars_spike}")
         
-        return dl_dt, adjoint_jumps, saved_vars_timestep, saved_vars_spike
+        return dl_dt, adjoint_jumps, grad_terms, saved_vars_timestep, saved_vars_spike
     
     def _build_in_hid_neuron_model(self, pop: Population,
                                    model: Union[AutoNeuronModel, NeuronModel],
@@ -1409,8 +1454,16 @@ class EventPropCompiler(Compiler):
                     "neurons defined in terms of AutoNeuronModel")
             
             # Build adjoint system from model
-            dl_dt, adjoint_jumps, saved_vars_timestep, saved_vars_spike =\
-                self._build_adjoint_system(model, False, self.reg_lambda != 0.0)
+            learn_params= [] if pop not in compile_state.optimisers \
+                else compile_state.optimisers[pop]
+            dl_dt, adjoint_jumps, grad_terms, saved_vars_timestep, saved_vars_spike =\
+                self._build_adjoint_system(model, learn_params, False, self.reg_lambda != 0.0)
+
+            additional_reset_vars = []
+            # Add variables for parameter gradients
+            for p in learn_params:
+                genn_model.add_var(f"{p}Gradient", "scalar", 0.0)
+                genn_model.make_param_var(p)
 
             # Add EGPs for adjoint variable value limits (to avoid pathological large jumps)
             dynamics_code = ""
@@ -1451,7 +1504,6 @@ class EventPropCompiler(Compiler):
 
             # If regularisation is enabled
             # **THINK** is this LIF-specific?
-            additional_reset_vars = []
             if self.reg_lambda != 0.0 and model.threshold != 0:
                 logger.debug("\tBuilding regulariser")
                 # Add state variables to hold spike count
@@ -1525,6 +1577,9 @@ class EventPropCompiler(Compiler):
 
             # Solve ODE and generate dynamics code
             dynamics_code += solve_ode(dl_dt, model.solver, model.sub_steps)
+            # Add gradient accumulation code
+            for p, expr in grad_terms.items():
+                dynamics_code += f"{p}Gradient += {sympy.ccode(expr)};\n"
             dynamics_code = Template(dynamics_code).substitute(
                 {s: f"tsRing{s}[tsRingOffset + tsRingReadOffset]" for s in saved_vars_timestep})
 
@@ -1574,8 +1629,14 @@ class EventPropCompiler(Compiler):
             example_timesteps=self.example_timesteps)
 
         # Build adjoint system from model
-        dl_dt, adjoint_jumps, saved_vars_timestep, saved_vars_spike =\
-            self._build_adjoint_system(model, True, False)
+        learn_params= [] if pop not in compile_state.optimisers \
+            else compile_state.optimisers[pop]
+        dl_dt, adjoint_jumps, grad_terms, saved_vars_timestep, saved_vars_spike =\
+            self._build_adjoint_system(model, learn_params, True, False)
+
+        # Add variables for parameter gradients
+        for p in learn_params:
+            genn_model.add_var(f"{p}Gradient", "scalar", 0.0)
 
         # Add continous drive term to LambdaV
         dl_dt[_get_lmd_sym(model.output_var_name)] += sympy.Symbol("drive")
@@ -1593,6 +1654,9 @@ class EventPropCompiler(Compiler):
                                np.empty(timestep_ring_size, dtype=np.float32))
             dyn_ts_reset_needed = True
 
+        logger.debug(f"\tReset variables: {genn_model.reset_vars}")
+        compile_state.add_neuron_reset_vars(
+            pop, genn_model.reset_vars, False, dyn_ts_reset_needed)
         # add read and write pointer for timestep-wise ring buffers
         if dyn_ts_reset_needed:
             genn_model.add_var("tsRingWriteOffset", "int", 0, reset=False)
@@ -1611,6 +1675,9 @@ class EventPropCompiler(Compiler):
 
         # Prepend continous adjoint system update
         dynamics_code = solve_ode(dl_dt, model.solver, model.sub_steps)
+        # Add gradient accumulation code
+        for p_grad, expr in grad_terms.items():
+            dynamics_code += f"{p_grad} += {sympy.ccode(expr)};\n"
         dynamics_code = Template(dynamics_code).substitute(
             {s: f"tsRing{s}[tsRingOffset + tsRingReadOffset]" for s in saved_vars_timestep})
 

--- a/ml_genn/ml_genn/losses/sparse_categorical_crossentropy.py
+++ b/ml_genn/ml_genn/losses/sparse_categorical_crossentropy.py
@@ -31,7 +31,10 @@ class SparseCategoricalCrossentropy(Loss):
                                f"be < {batch_size}")
 
         # Copy flattened y_true into view
-        genn_pop.vars["YTrue"].view[:len(y_true), 0] = y_true
+        if batch_size > 1:
+            genn_pop.vars["YTrue"].view[:len(y_true), 0] = y_true
+        else:
+            genn_pop.vars["YTrue"].view[0] = y_true
 
         # Push YTrue to device
         genn_pop.vars["YTrue"].push_to_device()


### PR DESCRIPTION
I have re-implemented how we designate which variables are trained with which optimiser.
In essence, during ```EventPropCompiler.compile()``` we pass an optional argument ```optimisers``` through ```**kwargs``` that is a dictionary of dictionaries, e.g.
```python
optimisers={connection: {"var": optimiser,
"var2": optimiser2},
connection2: {"var": optimiser3}
}
```
This is then passed through and interpreted so that each variable is optimised by the specified optimiser. I think ```compile()``` is the right point to specify optimisers, as one could now use the same ```EventPropCompiler``` to make a network for different training setups (different optimisers and learning rates for different parts of the network).

Furthermore, I have added training with respect to neuron parameters. The optimiser is defined through the same mechanism, e.g.
```python
optimisers={population: {"var": optimiser}}
```
The code runs simple examples, training weights, delays, and neuron parameters, including just training neuron parameters. It remains to be tested whether the gradient for training neuron parameters is correct, and this does something useful in an appropriate example.

TODO:
- [x] Implement sentinel syntax for easier specifying of defaults (I think this will allow us to remove the optimiser passed to the constructor)
- [x] Unify ``Connection``/``Layer``/``Populations`` in optimiser dictionary
- [ ] Checkpointing - should be trivial
- [ ] Optimisers should be created with ``get_object`` so you can use e.g. "adam" rather than having to import ``Adam``