### PR TITLE
Restrict symbols available in ``global_dict`` when parsing

### DIFF
--- a/ml_genn/ml_genn/utils/auto_model.py
+++ b/ml_genn/ml_genn/utils/auto_model.py
@@ -2,14 +2,26 @@ import numpy as np
 import sympy
 
 from typing import Any, MutableMapping, Optional, Tuple
-from .model import NeuronModel, SynapseModel
 from .value import Value
 
-from copy import deepcopy
-from itertools import chain
 from ..utils.value import get_auto_values
 
 Variables = MutableMapping[str, Tuple[Optional[str], Optional[str]]]
+
+# So lots of seemingly-innocent variable names don't conflict with bits of 
+# sympy, we want to significantly cut back the 'global dictionary' passed 
+# to parse_expr. We only require transcendental functions and pi. Symbol 
+# is automatically added around symbols by 'auto_symbol' transformation.
+# Literals get tagged with 'Integer', 'Float' and 'Rational' by other 
+# transformations
+_required_symbol_names = ["sin", "cos", "tan", "sec", "csc", "cot", "sinc",
+                          "asin", "acos", "atan", "asec", "acsc", "acot",
+                          "atan2", "exp", "ln", "log", "sinh", "cosh", 
+                          "tanh", "coth", "sech", "csch", "asinh", "acosh",
+                          "atanh", "acoth", "asech", "acsch", "sqrt", 
+                          "root", "cbrt", "pi", "Symbol", "Integer",
+                          "Rational", "Float"]
+_global_dict = {f: getattr(sympy, f) for f in _required_symbol_names}
 
 class AutoModel:
     def __init__(self, model: MutableMapping[str, Any],
@@ -28,13 +40,15 @@ class AutoModel:
         if "vars" in self.model:
             # Parse ODEs
             self.dx_dt =\
-                {sympy.Symbol(n): sympy.parse_expr(v[0])
+                {sympy.Symbol(n): sympy.parse_expr(v[0],
+                                                   global_dict=_global_dict)
                  for n, v in self.model["vars"].items()
                  if v[0] is not None}
             
             # Parse jumps
             self.jumps =\
-                {sympy.Symbol(n): sympy.parse_expr(v[1])
+                {sympy.Symbol(n): sympy.parse_expr(v[1],
+                                                   global_dict=_global_dict)
                  for n, v in self.model["vars"].items()
                  if v[1] is not None}
         else:
@@ -48,9 +62,11 @@ class AutoModel:
         
         # If provided, parse dynamics and jump and add to dicts
         if dynamics is not None:
-            self.dx_dt[sym] = sympy.parse_expr(dynamics)
+            self.dx_dt[sym] = sympy.parse_expr(dynamics, 
+                                               global_dict=_global_dict)
         if jump is not None:
-            self.jumps[sym] = sympy.parse_expr(jump)
+            self.jumps[sym] = sympy.parse_expr(jump,
+                                               global_dict=_global_dict)
 
         # Add value to dictionary
         self.var_vals[name] = value
@@ -72,7 +88,8 @@ class AutoNeuronModel(AutoModel):
         self.output_var_name = output_var_name
         
         if "threshold" in self.model and self.model["threshold"] is not None:
-            self.threshold = sympy.parse_expr(self.model["threshold"])
+            self.threshold = sympy.parse_expr(self.model["threshold"],
+                                              global_dict=_global_dict)
         else:
             self.threshold = 0
 
@@ -108,7 +125,7 @@ class AutoSynapseModel(AutoModel):
 
         if "inject_current" in self.model:
             self.inject_current = sympy.parse_expr(
-                self.model["inject_current"])
+                self.model["inject_current"], global_dict=_global_dict)
         else:
             raise RuntimeError("AutoSynapseModel requires an "
                                "'inject_current' expression.")

--- a/tests/ml_genn/neurons/test_user_neuron.py
+++ b/tests/ml_genn/neurons/test_user_neuron.py
@@ -1,0 +1,30 @@
+from ml_genn.neurons import UserNeuron
+
+def test_conflicting_var_name():
+    lif_beta = UserNeuron(vars={"beta": ("(-beta + Isyn) / tau_mem", "0.0")},
+                          threshold="beta - 1.0",
+                          output_var_name="beta",
+                          param_vals={"tau_mem": 20.0},
+                          var_vals={"beta": 0.0})
+    lif_beta.get_model(population=None, dt=1.0, batch_size=1)
+
+def test_izhikevich():
+    izhikevich = UserNeuron(vars={"V": ("(0.04 * V**2) + (5 * V) + 140 - U + Isyn", "c"),
+                                  "U": ("a * ((b * V) - U)", "U + d")},
+                          threshold="30.0",
+                          output_var_name="V",
+                          param_vals={"a": 0.02, "b": 0.02, "c": -65.0, "d": 8.0},
+                          var_vals={"V": -65.0, "U": -20.0})
+    izhikevich.get_model(population=None, dt=1.0, batch_size=1)
+
+def test_adexp():
+    adexp = UserNeuron(vars={"V": ("(1.0 / c) * ((-gL * (V - eL)) + (gL * deltaT * exp((V - vThresh) / deltaT)) + Isyn - W)", "vReset"),
+                             "W": ("(1.0 / tauW) * ((a * (V - eL)) - W)", "W + b")},
+                          threshold="-40.0",
+                          output_var_name="V",
+                          param_vals={"c": 281.0, "gL": 30.0, "eL": -70.6, 
+                                      "deltaT": 2.0, "vThresh": -50.4,
+                                      "vSpike": 10.0, "vReset": -70.6,
+                                      "tauW": 144.0, "a": 4.0, "b": 0.0805},
+                          var_vals={"V": -70.6, "W": 0.0})
+    adexp.get_model(population=None, dt=1.0, batch_size=1)


### PR DESCRIPTION
You can enter a lot of weird stuff into sympy expressions (https://github.com/sympy/sympy/blob/master/sympy/__init__.py gives some indication), much of which is not at all valid in the context of an ``AutoModel`` equation which meant you couldn't (for example) call variables "beta"! This PR restricts the amount of stuff that is available in these strings to what seems 'sensible'.

Fixes #178 