### PR TITLE
Loss recording

### DIFF
--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -27,7 +27,6 @@ from ..utils.model import (CustomUpdateModel, Model, NeuronModel,
                            SynapseModel, WeightUpdateModel)
 from ..utils.snippet import ConnectivitySnippet
 
-from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 from itertools import chain
@@ -309,7 +308,7 @@ class CompileState:
         self.update_trial_pops = []
         self.adjoint_limit_pops_vars = []
         self.optimisers = {}
-        self.loss_recorder_callbacks = []
+        self.loss_recorder_populations = []
 
         # Build list of output populations
         readouts = [p for p in network.populations
@@ -534,15 +533,9 @@ class LossRecorderState:
     losses: list = field(default_factory=list)
 
 class LossRecorderCallback(Callback, ABC):
-    def __init__(self, pop: Population, key: str, var_name: str):
+    def __init__(self, pop: Population, key: str):
         self.pop = pop
         self.key = key
-        self.var_name = var_name
-    
-    @abstractmethod
-    def calculate_loss(self, loss, example_timesteps: int,
-                       batch_size: int):
-        pass
 
     def create_state(self, compiled_network, **kwargs):
         return LossRecorderState(compiled_network)
@@ -551,13 +544,12 @@ class LossRecorderCallback(Callback, ABC):
         # Pull variable loss is calculated from from device
         cn = state.compiled_network
         genn_pop = cn.neuron_populations[self.pop]
-        genn_pop.vars[self.var_name].pull_from_device()
+        genn_pop.vars["LossSum"].pull_from_device()
 
         # Calculate loss and add to list
-        state.losses.apppend(
-            self.calculate_loss(genn_pop.vars[self.var_name].values,
-                                cn.example_timesteps,
-                                cn.genn_model.batch_size))
+        loss = np.sum(genn_pop.vars["LossSum"].view
+                      / cn.genn_model.batch_size)
+        state.losses.append(loss)
 
     def get_data(self, state):
         return self.key, state.losses
@@ -1308,6 +1300,11 @@ class EventPropCompiler(Compiler):
         if len(compile_state.ttfs_reduce_populations) > 0:
             base_train_callbacks.append(CustomUpdateOnBatchBegin("TTFSReduce"))
 
+        # Add callbacks for loss recording
+        for pop, key in compile_state.loss_recorder_populations:
+            base_train_callbacks.append(LossRecorderCallback(pop, key))
+            base_validate_callbacks.append(LossRecorderCallback(pop, key))
+
         # Add reset custom updates
         if compile_state.is_reset_custom_update_required:
             base_train_callbacks.append(CustomUpdateOnBatchBegin("Reset"))
@@ -1905,11 +1902,19 @@ class EventPropCompiler(Compiler):
             window_start, window_end = pop.neuron.readout.window_start_end(
                 self.example_timesteps, self.dt)
 
-        # If model is non-spiking - MSE and SCE losses of "voltage V" apply
+        # If we should record loss
         pop_loss = compile_state.losses[pop]
         if pop_loss.record_key is not None:
-            gen_record_code = lambda n: f"LossSum += -log({n});"
+            # Add variable to record into
             genn_model.add_var("LossSum", "scalar", 0.0)
+
+            # Define code generator function
+            gen_record_code = lambda n: f"LossSum += -log({n});"
+            
+            # Add population to list 
+            compile_state.loss_recorder_populations.append(
+                (pop, pop_loss.record_key))
+        # Otherwise don't generate any code
         else:
             gen_record_code = lambda n: ""
             
@@ -2008,10 +2013,6 @@ class EventPropCompiler(Compiler):
                     genn_model.add_var("Softmax", "scalar", 0.0,
                                        VarAccess.READ_ONLY_DUPLICATE,
                                        reset=False)
-
-                    # If we should record loss, add variable to sum into
-                    if pop_loss.record_key:
-                        compile_state.loss_calculators[pop] = LossCalculator("Softmax")
 
                     # If readout is AvgVar or SumVar
                     if isinstance(pop.neuron.readout, (AvgVar, SumVar)):

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -27,6 +27,7 @@ from ..utils.model import (CustomUpdateModel, Model, NeuronModel,
                            SynapseModel, WeightUpdateModel)
 from ..utils.snippet import ConnectivitySnippet
 
+from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 from itertools import chain
@@ -532,7 +533,7 @@ class LossRecorderState:
     compiled_network: CompiledTrainingNetwork
     losses: list = field(default_factory=list)
 
-class LossRecorderCallback(Callback, ABC):
+class LossRecorderCallbackBase(Callback):
     def __init__(self, pop: Population, key: str):
         self.pop = pop
         self.key = key
@@ -541,19 +542,33 @@ class LossRecorderCallback(Callback, ABC):
         return LossRecorderState(compiled_network)
 
     def on_batch_end(self, state, batch, metric_state):
-        # Pull variable loss is calculated from from device
-        cn = state.compiled_network
-        genn_pop = cn.neuron_populations[self.pop]
-        genn_pop.vars["LossSum"].pull_from_device()
+        # If this isn't the first batch (where there is no backward pass)
+        if batch > 0:
+            # Pull variable loss is calculated from from device
+            genn_pop = state.compiled_network.neuron_populations[self.pop]
+            genn_pop.vars["LossSum"].pull_from_device()
 
-        # Calculate loss and add to list
-        loss = np.sum(genn_pop.vars["LossSum"].view
-                      / cn.genn_model.batch_size)
-        state.losses.append(loss)
+            # Calculate loss and add to list
+            state.losses.append(
+                self.calculate_loss(state,  genn_pop.vars["LossSum"].view))
 
     def get_data(self, state):
         return self.key, state.losses
 
+    @abstractmethod
+    def calculate_loss(self, state, loss_sum):
+        pass
+
+class LossRecorderCallbackSCE(LossRecorderCallbackBase):
+    def calculate_loss(self, state, loss_sum):
+        batch_size = state.compiled_network.genn_model.batch_size
+        return np.sum(loss_sum) / batch_size
+
+class LossRecorderCallbackMSE(LossRecorderCallbackBase):
+    def calculate_loss(self, state, loss_sum):
+        batch_size = state.compiled_network.genn_model.batch_size
+        return np.sum(np.sqrt(loss_sum)) / batch_size
+        
 class EventPropCompiler(Compiler):
     """Compiler for training models using EventProp [Wunderlich2021]_.
 
@@ -1301,9 +1316,11 @@ class EventPropCompiler(Compiler):
             base_train_callbacks.append(CustomUpdateOnBatchBegin("TTFSReduce"))
 
         # Add callbacks for loss recording
-        for pop, key in compile_state.loss_recorder_populations:
-            base_train_callbacks.append(LossRecorderCallback(pop, key))
-            base_validate_callbacks.append(LossRecorderCallback(pop, key))
+        for pop, key, sce_loss in compile_state.loss_recorder_populations:
+            L = (LossRecorderCallbackSCE if sce_loss
+                  else LossRecorderCallbackMSE)
+            base_train_callbacks.append(L(pop, key))
+            base_validate_callbacks.append(L(pop, key))
 
         # Add reset custom updates
         if compile_state.is_reset_custom_update_required:
@@ -1902,27 +1919,36 @@ class EventPropCompiler(Compiler):
             window_start, window_end = pop.neuron.readout.window_start_end(
                 self.example_timesteps, self.dt)
 
-        # If we should record loss
+        # Classify loss
         pop_loss = compile_state.losses[pop]
-        if pop_loss.record_key is not None:
-            # Add variable to record into
-            genn_model.add_var("LossSum", "scalar", 0.0)
-
-            # Define code generator function
-            gen_record_code = lambda n: f"LossSum += -log({n});"
-            
-            # Add population to list 
-            compile_state.loss_recorder_populations.append(
-                (pop, pop_loss.record_key))
-        # Otherwise don't generate any code
-        else:
-            gen_record_code = lambda n: ""
-            
-        # If model is non-spiking - MSE and SCE losses of "voltage V" apply
         sce_loss = isinstance(pop_loss, SparseCategoricalCrossentropy)
         mse_loss = isinstance(pop_loss, MeanSquareError)
         per_neuron_mse_loss = isinstance(pop_loss, PerNeuronMeanSquareError)
         rmse_loss = isinstance(pop_loss, RelativeMeanSquareError)
+        
+        # If we should record loss
+        if pop_loss.record_key is not None:
+            # Add variable to record into
+            genn_model.add_var("LossSum", "scalar", 0.0)
+
+            # Define templates for loss recording code
+            gen_record_code = Template("LossSum += ($n);")
+            gen_first_timestep_record_code = Template(
+                """
+                if(t == 0.0) {
+                    LossSum = ($n);
+                }
+                """)
+            
+            # Add population to list 
+            compile_state.loss_recorder_populations.append(
+                (pop, pop_loss.record_key, sce_loss))
+        # Otherwise provide empty templates
+        else:
+            gen_record_code = Template("")
+            gen_first_timestep_record_code = Template("")
+            
+        # If model is non-spiking - MSE and SCE losses of "voltage V" apply
         if "threshold" not in model.model or model.model["threshold"] is None:
             # Check adjoint system is also jump-less
             assert len(saved_vars_spike) == 0
@@ -1955,7 +1981,7 @@ class EventPropCompiler(Compiler):
                             const scalar loss = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
 
                             if(id == YTrueBack) {{
-                                {gen_record_code('loss')}
+                                {gen_record_code.substitute(n='-log(loss)')}
                                 drive = (1.0 - loss) / (num_batch * {window_end-window_start});
                             }}
                             else {{
@@ -1991,7 +2017,7 @@ class EventPropCompiler(Compiler):
                         if (Trial > 0) {{
                             tsRingReadOffset--;
                             const scalar loss = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
-                            {gen_record_code('loss')}
+                            {gen_record_code.substitute(n='loss * loss')}
                             drive = loss / (num_batch * {self.dt * self.example_timesteps});
                         }}
                         
@@ -2019,7 +2045,7 @@ class EventPropCompiler(Compiler):
                         ro = pop.neuron.readout
                         code = f"""
                            if(id == YTrueBack) {{
-                               {gen_record_code('Softmax')}
+                               {gen_first_timestep_record_code.substitute(n='-log(Softmax)')}
                                drive = (1.0 - Softmax) / (num_batch * {window_end-window_start});
                             }}
                             else {{
@@ -2050,7 +2076,7 @@ class EventPropCompiler(Compiler):
                         T = self.dt * self.example_timesteps
                         code = f"""
                             if(id == YTrueBack) {{
-                                {gen_record_code('Softmax')}
+                                {gen_first_timestep_record_code.substitute(n='-log(Softmax)')}
                                 drive = ((1.0 - Softmax) * exp(-(1.0 - (t * {local_t_scale})))) / (num_batch * {window_end - window_start});
                             }}
                             else {{
@@ -2090,7 +2116,7 @@ class EventPropCompiler(Compiler):
                             scalar drive = 0.0;
                             if (Trial > 0 && fabs(backT - {out_var_name}MaxTimeBack) < 1e-3*dt) {{
                                 if(id == YTrueBack) {{
-                                    {gen_record_code('Softmax')}
+                                    {gen_record_code.substitute(n='-log(Softmax)')}
                                     drive = (1.0 - Softmax) / (num_batch * {self.dt * self.example_timesteps});
                                 }}
                                 else {{
@@ -2217,7 +2243,7 @@ class EventPropCompiler(Compiler):
                             if (id == YTrueBack) {{
                                 const scalar fst = {1.01 * window_end} + TFirstSpikeBack;
                                 drive_p = (((1.0 - Softmax) / {self.softmax_temperature}) + ({self.ttfs_alpha} / (fst * fst))) / {self.batch_size};
-                                {gen_record_code('Softmax')}
+                                {gen_record_code.substitute(n='-log(Softmax)')}
                             }}
                             else {{
                                 drive_p = - Softmax / ({self.softmax_temperature * self.batch_size});
@@ -2239,7 +2265,7 @@ class EventPropCompiler(Compiler):
                         scalar drive_p = 0.0;
                         if (fabs(backT + TFirstSpikeBack) < 1e-3*dt) {{
                             drive_p = (-TFirstSpikeBack-YTrueBack);
-                            {gen_record_code('drive_p')}
+                            {gen_record_code.substitute(n='drive_p * drive_p')}
                         }}
                         {transition_code}
                         """
@@ -2274,7 +2300,7 @@ class EventPropCompiler(Compiler):
                         if (fabs(backT + TFirstSpikeBack) < 1e-3*dt) {{
                             if(id == YTrueBack) {{
                                 drive_p = (TFirstSpikeSumBack - (num_neurons * TFirstSpikeTrueBack) + ((num_neurons - 1) * Delta));
-                                {gen_record_code('drive_p')}
+                                {gen_record_code.substitute(n='drive_p * drive_p')}
                             }}
                             else {{
                                 drive_p = ((-TFirstSpikeBack + TFirstSpikeTrueBack) - Delta);

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -2080,7 +2080,7 @@ class EventPropCompiler(Compiler):
                                 drive = ((1.0 - Softmax) * exp(-(1.0 - (t * {local_t_scale})))) / (num_batch * {window_end - window_start});
                             }}
                             else {{
-                                drive = -(-Softmax * exp(-(1.0 - (t * {local_t_scale})))) / (num_batch * {window_end - window_start});
+                                drive = -Softmax * exp(-(1.0 - (t * {local_t_scale}))) / (num_batch * {window_end - window_start});
                             }}
                         """
                         genn_model.prepend_sim_code(

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1908,10 +1908,10 @@ class EventPropCompiler(Compiler):
         # If model is non-spiking - MSE and SCE losses of "voltage V" apply
         pop_loss = compile_state.losses[pop]
         if pop_loss.record_key is not None:
-            record_code = lambda n: f"LossSum += -log({n});"
+            gen_record_code = lambda n: f"LossSum += -log({n});"
             genn_model.add_var("LossSum", "scalar", 0.0)
         else:
-            record_code = lambda n: ""
+            gen_record_code = lambda n: ""
             
         # If model is non-spiking - MSE and SCE losses of "voltage V" apply
         sce_loss = isinstance(pop_loss, SparseCategoricalCrossentropy)
@@ -1950,7 +1950,7 @@ class EventPropCompiler(Compiler):
                             const scalar loss = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
 
                             if(id == YTrueBack) {{
-                                {record_code}
+                                {gen_record_code('loss')}
                                 drive = (1.0 - loss) / (num_batch * {window_end-window_start});
                             }}
                             else {{
@@ -1986,7 +1986,7 @@ class EventPropCompiler(Compiler):
                         if (Trial > 0) {{
                             tsRingReadOffset--;
                             const scalar loss = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
-                            {record_code('loss')}
+                            {gen_record_code('loss')}
                             drive = loss / (num_batch * {self.dt * self.example_timesteps});
                         }}
                         
@@ -2018,7 +2018,7 @@ class EventPropCompiler(Compiler):
                         ro = pop.neuron.readout
                         code = f"""
                            if(id == YTrueBack) {{
-                               {record_code('Softmax')}
+                               {gen_record_code('Softmax')}
                                drive = (1.0 - Softmax) / (num_batch * {window_end-window_start});
                             }}
                             else {{
@@ -2049,7 +2049,7 @@ class EventPropCompiler(Compiler):
                         T = self.dt * self.example_timesteps
                         code = f"""
                             if(id == YTrueBack) {{
-                                {record_code('Softmax')}
+                                {gen_record_code('Softmax')}
                                 drive = ((1.0 - Softmax) * exp(-(1.0 - (t * {local_t_scale})))) / (num_batch * {window_end - window_start});
                             }}
                             else {{
@@ -2089,7 +2089,7 @@ class EventPropCompiler(Compiler):
                             scalar drive = 0.0;
                             if (Trial > 0 && fabs(backT - {out_var_name}MaxTimeBack) < 1e-3*dt) {{
                                 if(id == YTrueBack) {{
-                                    {record_code('Softmax')}
+                                    {gen_record_code('Softmax')}
                                     drive = (1.0 - Softmax) / (num_batch * {self.dt * self.example_timesteps});
                                 }}
                                 else {{
@@ -2216,6 +2216,7 @@ class EventPropCompiler(Compiler):
                             if (id == YTrueBack) {{
                                 const scalar fst = {1.01 * window_end} + TFirstSpikeBack;
                                 drive_p = (((1.0 - Softmax) / {self.softmax_temperature}) + ({self.ttfs_alpha} / (fst * fst))) / {self.batch_size};
+                                {gen_record_code('Softmax')}
                             }}
                             else {{
                                 drive_p = - Softmax / ({self.softmax_temperature * self.batch_size});
@@ -2237,6 +2238,7 @@ class EventPropCompiler(Compiler):
                         scalar drive_p = 0.0;
                         if (fabs(backT + TFirstSpikeBack) < 1e-3*dt) {{
                             drive_p = (-TFirstSpikeBack-YTrueBack);
+                            {gen_record_code('drive_p')}
                         }}
                         {transition_code}
                         """
@@ -2271,6 +2273,7 @@ class EventPropCompiler(Compiler):
                         if (fabs(backT + TFirstSpikeBack) < 1e-3*dt) {{
                             if(id == YTrueBack) {{
                                 drive_p = (TFirstSpikeSumBack - (num_neurons * TFirstSpikeTrueBack) + ((num_neurons - 1) * Delta));
+                                {gen_record_code('drive_p')}
                             }}
                             else {{
                                 drive_p = ((-TFirstSpikeBack + TFirstSpikeTrueBack) - Delta);

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1907,6 +1907,13 @@ class EventPropCompiler(Compiler):
 
         # If model is non-spiking - MSE and SCE losses of "voltage V" apply
         pop_loss = compile_state.losses[pop]
+        if pop_loss.record_key is not None:
+            record_code = lambda n: f"LossSum += -log({n});"
+            genn_model.add_var("LossSum", "scalar", 0.0)
+        else:
+            record_code = lambda n: ""
+            
+        # If model is non-spiking - MSE and SCE losses of "voltage V" apply
         sce_loss = isinstance(pop_loss, SparseCategoricalCrossentropy)
         mse_loss = isinstance(pop_loss, MeanSquareError)
         per_neuron_mse_loss = isinstance(pop_loss, PerNeuronMeanSquareError)
@@ -1929,16 +1936,6 @@ class EventPropCompiler(Compiler):
                 ring_size = self.batch_size * np.prod(pop.shape) * 2 * self.example_timesteps
                 genn_model.add_egp("RingOutputLossTerm", "scalar*", 
                                    np.empty(ring_size, dtype=np.float32))
-
-                # If we should record loss, add variable to sum into
-                # and generate code string to add log loss to it
-                if pop_loss.record_key is not None:
-                    record_code = "LossSum += -log(loss);"
-                    genn_model.add_var("LossSum", "scalar", 0.0)
-                    compile_state.loss_recorder_callbacks.append()
-                        
-                else:
-                    record_code = ""
 
                 # We have a variable ring so it will need resetting
                 reset_v_ring = True
@@ -1989,7 +1986,7 @@ class EventPropCompiler(Compiler):
                         if (Trial > 0) {{
                             tsRingReadOffset--;
                             const scalar loss = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
-                            {record_code}
+                            {record_code('loss')}
                             drive = loss / (num_batch * {self.dt * self.example_timesteps});
                         }}
                         
@@ -2020,8 +2017,13 @@ class EventPropCompiler(Compiler):
                     if isinstance(pop.neuron.readout, (AvgVar, SumVar)):
                         ro = pop.neuron.readout
                         code = f"""
-                            const scalar g = (id == YTrueBack) ? (1.0 - Softmax) : -Softmax;
-                            drive = g / (num_batch * {window_end-window_start});
+                           if(id == YTrueBack) {{
+                               {record_code('Softmax')}
+                               drive = (1.0 - Softmax) / (num_batch * {window_end-window_start});
+                            }}
+                            else {{
+                                drive = -Softmax / (num_batch * {window_end-window_start});
+                            }}
                         """
                         genn_model.prepend_sim_code(
                             f"""
@@ -2046,8 +2048,13 @@ class EventPropCompiler(Compiler):
                         local_t_scale = 1.0 / (window_end - window_start)
                         T = self.dt * self.example_timesteps
                         code = f"""
-                            const scalar g = (id == YTrueBack) ? (1.0 - Softmax) : -Softmax;
-                            drive = (g * exp(-({T}-t-{window_start}) * {local_t_scale})) / (num_batch * {window_end - window_start});
+                            if(id == YTrueBack) {{
+                                {record_code('Softmax')}
+                                drive = ((1.0 - Softmax) * exp(-(1.0 - (t * {local_t_scale})))) / (num_batch * {window_end - window_start});
+                            }}
+                            else {{
+                                drive = -(-Softmax * exp(-(1.0 - (t * {local_t_scale})))) / (num_batch * {window_end - window_start});
+                            }}
                         """
                         genn_model.prepend_sim_code(
                             f"""
@@ -2081,8 +2088,13 @@ class EventPropCompiler(Compiler):
                             const scalar backT = {self.example_timesteps * self.dt} - t - dt;
                             scalar drive = 0.0;
                             if (Trial > 0 && fabs(backT - {out_var_name}MaxTimeBack) < 1e-3*dt) {{
-                                const scalar g = (id == YTrueBack) ? (1.0 - Softmax) : -Softmax;
-                                drive = g / (num_batch * {self.dt * self.example_timesteps});
+                                if(id == YTrueBack) {{
+                                    {record_code('Softmax')}
+                                    drive = (1.0 - Softmax) / (num_batch * {self.dt * self.example_timesteps});
+                                }}
+                                else {{
+                                    drive = -Softmax / (num_batch * {self.dt * self.example_timesteps});
+                                }}
                             }}
                             {read_pointer_code}
                             {dynamics_code}

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -2,6 +2,7 @@ import logging
 import numpy as np
 import sympy
 
+from abc import ABC
 from string import Template
 from typing import Mapping, Union, Tuple
 from pygenn import (CustomUpdateVarAccess, SynapseMatrixType,
@@ -26,7 +27,9 @@ from ..utils.model import (CustomUpdateModel, Model, NeuronModel,
                            SynapseModel, WeightUpdateModel)
 from ..utils.snippet import ConnectivitySnippet
 
+from abc import abstractmethod
 from copy import deepcopy
+from dataclasses import dataclass, field
 from itertools import chain
 from warnings import warn
 from pygenn import (create_egp_ref, create_psm_var_ref,
@@ -291,6 +294,7 @@ def _add_required_wum_psm_parameters(model: AutoSynapseModel,
                              WeightUpdateModel.add_psm_var_ref,
                              WeightUpdateModel.has_psm_var_ref)
 
+
 class CompileState:
     def __init__(self, network: Network, losses, optimisers, 
                  supported_matrix_type, backend_name):
@@ -305,6 +309,7 @@ class CompileState:
         self.update_trial_pops = []
         self.adjoint_limit_pops_vars = []
         self.optimisers = {}
+        self.loss_recorder_callbacks = []
 
         # Build list of output populations
         readouts = [p for p in network.populations
@@ -522,6 +527,40 @@ class CustomUpdateOnFirstBatchEnd(Callback):
             logger.debug(f"Running custom update {self.name} "
                          f"at end of batch {batch}")
             state.genn_model.custom_update(self.name)
+
+@dataclass
+class LossRecorderState:
+    compiled_network: CompiledTrainingNetwork
+    losses: list = field(default_factory=list)
+
+class LossRecorderCallback(Callback, ABC):
+    def __init__(self, pop: Population, key: str, var_name: str):
+        self.pop = pop
+        self.key = key
+        self.var_name = var_name
+    
+    @abstractmethod
+    def calculate_loss(self, loss, example_timesteps: int,
+                       batch_size: int):
+        pass
+
+    def create_state(self, compiled_network, **kwargs):
+        return LossRecorderState(compiled_network)
+
+    def on_batch_end(self, state, batch, metric_state):
+        # Pull variable loss is calculated from from device
+        cn = state.compiled_network
+        genn_pop = cn.neuron_populations[self.pop]
+        genn_pop.vars[self.var_name].pull_from_device()
+
+        # Calculate loss and add to list
+        state.losses.apppend(
+            self.calculate_loss(genn_pop.vars[self.var_name].values,
+                                cn.example_timesteps,
+                                cn.genn_model.batch_size))
+
+    def get_data(self, state):
+        return self.key, state.losses
 
 class EventPropCompiler(Compiler):
     """Compiler for training models using EventProp [Wunderlich2021]_.
@@ -1885,11 +1924,21 @@ class EventPropCompiler(Compiler):
                 if not dyn_ts_reset_needed:
                     genn_model.add_var("tsRingWriteOffset", "int", 0, reset=False)
                     genn_model.add_var("tsRingReadOffset", "int", 0, reset=False)
-
+ 
                 # Add EGP for softmax V (SCE) or regression difference (MSE) ring variable
                 ring_size = self.batch_size * np.prod(pop.shape) * 2 * self.example_timesteps
                 genn_model.add_egp("RingOutputLossTerm", "scalar*", 
                                    np.empty(ring_size, dtype=np.float32))
+
+                # If we should record loss, add variable to sum into
+                # and generate code string to add log loss to it
+                if pop_loss.record_key is not None:
+                    record_code = "LossSum += -log(loss);"
+                    genn_model.add_var("LossSum", "scalar", 0.0)
+                    compile_state.loss_recorder_callbacks.append()
+                        
+                else:
+                    record_code = ""
 
                 # We have a variable ring so it will need resetting
                 reset_v_ring = True
@@ -1901,9 +1950,15 @@ class EventPropCompiler(Compiler):
                         ro = pop.neuron.readout
                         code = """
                             tsRingReadOffset--;
-                            const scalar softmax = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
-                            const scalar g = (id == YTrueBack) ? (1.0 - softmax) : -softmax;
-                            drive = g / (num_batch * {window_end-window_start});
+                            const scalar loss = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
+
+                            if(id == YTrueBack) {{
+                                {record_code}
+                                drive = (1.0 - loss) / (num_batch * {window_end-window_start});
+                            }}
+                            else {{
+                                drive = -loss / (num_batch * {window_end-window_start});
+                            }}
                         """
                         genn_model.prepend_sim_code(
                             f"""
@@ -1933,8 +1988,9 @@ class EventPropCompiler(Compiler):
                         const int tsRingOffset = (batch * num_neurons * {2 * self.example_timesteps}) + (id * {2 * self.example_timesteps});
                         if (Trial > 0) {{
                             tsRingReadOffset--;
-                            const scalar error = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
-                            drive = error / (num_batch * {self.dt * self.example_timesteps});
+                            const scalar loss = RingOutputLossTerm[tsRingOffset + tsRingReadOffset];
+                            {record_code}
+                            drive = loss / (num_batch * {self.dt * self.example_timesteps});
                         }}
                         
                         {dynamics_code}
@@ -1944,8 +2000,7 @@ class EventPropCompiler(Compiler):
                     genn_model.append_sim_code(
                         f"""
                         const unsigned int timestep = (int)round(t / dt);
-                        const unsigned int index = (batch * {self.example_timesteps} * num_neurons)
-                        + (timestep * num_neurons) + id;
+                        const unsigned int index = (batch * {self.example_timesteps} * num_neurons) + (timestep * num_neurons) + id;
                         RingOutputLossTerm[tsRingOffset + tsRingWriteOffset] = YTrue[index] - {out_var_name};
                         tsRingWriteOffset++;
                         """) 
@@ -1956,6 +2011,10 @@ class EventPropCompiler(Compiler):
                     genn_model.add_var("Softmax", "scalar", 0.0,
                                        VarAccess.READ_ONLY_DUPLICATE,
                                        reset=False)
+
+                    # If we should record loss, add variable to sum into
+                    if pop_loss.record_key:
+                        compile_state.loss_calculators[pop] = LossCalculator("Softmax")
 
                     # If readout is AvgVar or SumVar
                     if isinstance(pop.neuron.readout, (AvgVar, SumVar)):

--- a/ml_genn/ml_genn/losses/loss.py
+++ b/ml_genn/ml_genn/losses/loss.py
@@ -5,6 +5,9 @@ from abc import abstractproperty
 
 class Loss(ABC):
     """Base class for all loss functions"""
+    def __init__(self, record: bool = False):
+        self._record = record
+    
     @abstractproperty
     def ground_truth(self) -> str:
         """Gets ground truth class required by this loss function
@@ -13,3 +16,7 @@ class Loss(ABC):
             str: name of ground truth class
         """
         pass
+
+    @property
+    def record(self):
+        return self._record

--- a/ml_genn/ml_genn/losses/loss.py
+++ b/ml_genn/ml_genn/losses/loss.py
@@ -1,12 +1,13 @@
 from abc import ABC
+from typing import Any, Optional
 
 from abc import abstractproperty
 
 
 class Loss(ABC):
     """Base class for all loss functions"""
-    def __init__(self, record: bool = False):
-        self._record = record
+    def __init__(self, record_key: Optional[Any] = None):
+        self._record_key = record_key
     
     @abstractproperty
     def ground_truth(self) -> str:
@@ -18,5 +19,6 @@ class Loss(ABC):
         pass
 
     @property
-    def record(self):
-        return self._record
+    def record_key(self) -> Optional[Any]:
+        """Key to record loss with"""
+        return self._record_key

--- a/ml_genn/ml_genn/losses/relative_mean_square_error.py
+++ b/ml_genn/ml_genn/losses/relative_mean_square_error.py
@@ -1,3 +1,4 @@
+from typing import Any, Optional
 from .loss import Loss
 
 
@@ -5,8 +6,8 @@ class RelativeMeanSquareError(Loss):
     """Computes the mean squared error between prediction of incorrect 
     outputs and correct output when there are two or more label classes, 
     specified as integers."""
-    def __init__(self, delta: float, record: bool = False):
-        super().__init__(record)
+    def __init__(self, delta: float, record_key: Optional[Any] = None):
+        super().__init__(record_key)
 
         self.delta = delta
 

--- a/ml_genn/ml_genn/losses/relative_mean_square_error.py
+++ b/ml_genn/ml_genn/losses/relative_mean_square_error.py
@@ -5,7 +5,9 @@ class RelativeMeanSquareError(Loss):
     """Computes the mean squared error between prediction of incorrect 
     outputs and correct output when there are two or more label classes, 
     specified as integers."""
-    def __init__(self, delta: float):
+    def __init__(self, delta: float, record: bool = False):
+        super().__init__(record)
+
         self.delta = delta
 
     @property


### PR DESCRIPTION
After some thought and fiddling, my conclusion is that loss is a compiler-specific thing **and** needs calculating in the backward pass so recording it isn't really something that can be easily or sensibly implemented as a metric. Therefore, this PR adds functionality to generate loss-calculating terms to the event prop backward pass and stores the data in a callback added by the compiler (in the same way rewiring stats are stored with Deep-R in #94).

However,  I cannot quite figure out how all the calculations works in the original genn_eventprop code

