### PR TITLE
Zero spike counts at the start of each batch to get rid of bleeding spikes

### DIFF
--- a/ml_genn/ml_genn/compilers/compiler.py
+++ b/ml_genn/ml_genn/compilers/compiler.py
@@ -22,8 +22,9 @@ from copy import copy, deepcopy
 from pygenn import (create_custom_connectivity_update_model,
                     create_custom_update_model, create_den_delay_var_ref,
                     create_neuron_model, create_out_post_var_ref,
-                    create_postsynaptic_model, create_weight_update_model,
-                    create_var_ref, init_postsynaptic, init_weight_update)
+                    create_postsynaptic_model, create_src_spike_count_var_ref,
+                    create_weight_update_model, create_var_ref,
+                    init_postsynaptic, init_weight_update)
 from string import digits
 from .weight_update_models import (get_static_pulse_delay_model, 
                                    get_signed_static_pulse_delay_model)
@@ -426,10 +427,22 @@ class Compiler:
         
         # Configure EGPs
         set_egp(ccu_egp_vals, genn_ccu.extra_global_params)
-    
+
         # Configure var init EGPs
         set_var_egps(ccu_var_egp_vals, genn_ccu.vars)
         return genn_ccu
+
+    def add_spike_count_zero_custom_update(self, genn_model, genn_syn_pop,
+                                           group: str, name: str):
+        # Create reset model
+        zero_spike_count_model = create_reset_custom_update(
+            [("SpikeCount", "uint32_t", 0)],
+            lambda _: create_src_spike_count_var_ref(genn_syn_pop))
+        
+        # Add GeNN custom update to model
+        self.add_custom_update(
+            genn_model, zero_spike_count_model, 
+            group, name)
 
     def add_out_post_zero_custom_update(self, genn_model, genn_syn_pop,
                                         group: str, name: str):

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1225,12 +1225,17 @@ class EventPropCompiler(Compiler):
             genn_pop = neuron_populations[p]
             self._add_softmax_buffer_custom_updates(genn_model, genn_pop, i)
 
-        # Loop through connections and add custom updates to zero out post
+        # Loop through connections
         for i, genn_syn_pop in enumerate(connection_populations.values()):
+            # Add custom updates to zero out post to reset group
             self.add_out_post_zero_custom_update(genn_model, genn_syn_pop,
-                                                 "ZeroOutPost",
+                                                 "Reset",
                                                  f"CUZeroOutPost{i}")
-        
+            # And another to zero spike counts
+            self.add_spike_count_zero_custom_update(genn_model, genn_syn_pop,
+                                                    "Reset",
+                                                    f"CUZeroSpikeCount{i}")
+
         # Loop through populations which require spike 
         # count reductions add custom update
         for i, p in enumerate(compile_state.spike_count_populations):
@@ -1282,15 +1287,6 @@ class EventPropCompiler(Compiler):
         # on populations which require it
         for p in compile_state.update_trial_pops:
             base_train_callbacks.append(UpdateTrial(neuron_populations[p]))
-
-        # Add callbacks to zero out post on all connections
-        last_timestep = self.example_timesteps - 1
-        base_train_callbacks.append(
-            CustomUpdateOnTimestepBegin("ZeroOutPost",
-                                        lambda t: t == last_timestep))
-        base_validate_callbacks.append(
-            CustomUpdateOnTimestepBegin("ZeroOutPost",
-                                        lambda t: t == last_timestep))
 
         # If softmax calculation is required at end of batch, add callbacks
         if len(compile_state.batch_softmax_populations) > 0:

--- a/ml_genn/ml_genn/compilers/inference_compiler.py
+++ b/ml_genn/ml_genn/compilers/inference_compiler.py
@@ -462,6 +462,12 @@ class InferenceCompiler(Compiler):
                     genn_model, connection_populations[c],
                     "Reset", f"CUZeroOutPost{i}")
     
+        # Create custom updates in "Reset" group to zero spike counts
+        for i, genn_syn_pop in enumerate(connection_populations.values()):
+            self.add_spike_count_zero_custom_update(
+                genn_model, genn_syn_pop,
+                "Reset", f"CUZeroSpikeCount{i}")
+
         base_callbacks = [CustomUpdateOnBatchBegin("Reset")]
 
         return CompiledInferenceNetwork(genn_model, neuron_populations,


### PR DESCRIPTION
Using the functionality in https://github.com/genn-team/genn/pull/742, we can now get rid of the extra ``ZeroOutPost`` custom update which got launched in the last timestep of each batch and instead:

1. Zero "OutPost" and "DenDelay"
2. Zero spike counts

in the main "Reset" callback that gets run at the start of each batch. This should save 1 kernel launch per batch which is always a good thing and simplifies things a little (as well as hopefully finally fixing spike bleeding!). Inference compiler also adds this to every connection.