### PR TITLE
Per layer regularisation configuration

### DIFF
--- a/examples/event_prop/pattern_recognition.py
+++ b/examples/event_prop/pattern_recognition.py
@@ -91,8 +91,8 @@ with network:
     Connection(hidden, output, Dense(Normal(sd=1.0 / np.sqrt(NUM_HIDDEN))), Exponential(TAU_SYN))
 
 compiler = EventPropCompiler(example_timesteps=1000, losses="mean_square_error", max_spikes=1500)
-compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(LR)}}
-                                regularisers={"all_populations": SpikeCount(1e-8, 10)})
+compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(LR)}},
+                                regularisers={"all_hidden_populations": SpikeCount(1e-8, 10)})
 
 with compiled_net:
     def alpha_schedule(epoch, alpha):

--- a/examples/event_prop/pattern_recognition.py
+++ b/examples/event_prop/pattern_recognition.py
@@ -9,6 +9,7 @@ from ml_genn.connectivity import Dense
 from ml_genn.initializers import Normal
 from ml_genn.neurons import LeakyIntegrate, LeakyIntegrateFire, SpikeInput
 from ml_genn.readouts import Var
+from ml_genn.regularisers import SpikeCount
 from ml_genn.synapses import Exponential
 from ml_genn.optimisers import Adam
 
@@ -89,9 +90,9 @@ with network:
     #Connection(hidden, hidden, Dense(Normal(sd=0.5 / np.sqrt(NUM_HIDDEN))), Exponential(TAU_SYN))
     Connection(hidden, output, Dense(Normal(sd=1.0 / np.sqrt(NUM_HIDDEN))), Exponential(TAU_SYN))
 
-compiler = EventPropCompiler(example_timesteps=1000, losses="mean_square_error",
-                             reg_lambda=1e-8, reg_nu_upper=10, max_spikes=1500)
-compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(LR)}})
+compiler = EventPropCompiler(example_timesteps=1000, losses="mean_square_error", max_spikes=1500)
+compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(LR)}}
+                                regularisers={"all_populations": SpikeCount(1e-8, 10)})
 
 with compiled_net:
     def alpha_schedule(epoch, alpha):

--- a/examples/event_prop/shd.py
+++ b/examples/event_prop/shd.py
@@ -72,7 +72,7 @@ if TRAIN:
                                  max_spikes=1500, batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
     compiled_net = compiler.compile(network, 
                                     optimisers={"all_connections": {"weight": "adam"}},
-                                    regularisers={"all_populations": SpikeCount(strength=1e-10, target=14)})
+                                    regularisers={"all_hidden_populations": SpikeCount(strength=1e-10, target=14)})
 
     with compiled_net:
         # Evaluate model on numpy dataset

--- a/examples/event_prop/shd.py
+++ b/examples/event_prop/shd.py
@@ -8,6 +8,7 @@ from ml_genn.compilers import EventPropCompiler, InferenceCompiler
 from ml_genn.connectivity import Dense,FixedProbability
 from ml_genn.initializers import Normal
 from ml_genn.neurons import LeakyIntegrate, LeakyIntegrateFire, SpikeInput
+from ml_genn.regularisers import SpikeCount
 from ml_genn.serialisers import Numpy
 from ml_genn.synapses import Exponential
 from tonic.datasets import SHD
@@ -68,9 +69,10 @@ max_example_timesteps = int(np.ceil(latest_spike_time / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 reg_lambda=1e-10, reg_nu_upper=14, max_spikes=1500, 
-                                 batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"}})
+                                 max_spikes=1500, batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network, 
+                                    optimisers={"all_connections": {"weight": "adam"}},
+                                    regularisers={"all_populations": SpikeCount(strength=1e-10, target=14)})
 
     with compiled_net:
         # Evaluate model on numpy dataset

--- a/examples/event_prop/shd_augment.py
+++ b/examples/event_prop/shd_augment.py
@@ -9,6 +9,7 @@ from ml_genn.connectivity import Dense,FixedProbability
 from ml_genn.initializers import Normal
 from ml_genn.neurons import LeakyIntegrate, LeakyIntegrateFire, SpikeInput
 from ml_genn.optimisers import Adam
+from ml_genn.regularisers import SpikeCount
 from ml_genn.serialisers import Numpy
 from ml_genn.synapses import Exponential
 from tonic import DiskCachedDataset
@@ -108,9 +109,10 @@ max_example_timesteps = int(np.ceil(latest_spike_time / DT))
 if TRAIN:
     compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                                  losses="sparse_categorical_crossentropy",
-                                 reg_lambda=4e-09, reg_nu_upper=14, max_spikes=1500, 
-                                 batch_size=BATCH_SIZE, kernel_profiling=KERNEL_PROFILING)
-    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"}})
+                                 max_spikes=1500, batch_size=BATCH_SIZE, 
+                                 kernel_profiling=KERNEL_PROFILING)
+    compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"}},
+                                    regularisers={"all_populations": SpikeCount(4e-09, 14)})
 
     with compiled_net:
         # Loop through epochs

--- a/examples/event_prop/shd_augment.py
+++ b/examples/event_prop/shd_augment.py
@@ -112,7 +112,7 @@ if TRAIN:
                                  max_spikes=1500, batch_size=BATCH_SIZE, 
                                  kernel_profiling=KERNEL_PROFILING)
     compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": "adam"}},
-                                    regularisers={"all_populations": SpikeCount(4e-09, 14)})
+                                    regularisers={"all_hidden_populations": SpikeCount(4e-09, 14)})
 
     with compiled_net:
         # Loop through epochs

--- a/examples/event_prop/shd_delay_shift_blend.py
+++ b/examples/event_prop/shd_delay_shift_blend.py
@@ -206,7 +206,7 @@ compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                              losses="sparse_categorical_crossentropy",
                              max_spikes=1500, batch_size=BATCH_SIZE)
 compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(0.001 * 0.01)}},
-                                regularisers={"all_populations": SpikeCount(5e-11, 14)})
+                                regularisers={"all_hidden_populations": SpikeCount(5e-11, 14)})
 best_acc, best_e = 0, 0
 with compiled_net:
     # Loop through epochs

--- a/examples/event_prop/shd_delay_shift_blend.py
+++ b/examples/event_prop/shd_delay_shift_blend.py
@@ -7,6 +7,7 @@ from ml_genn.connectivity import Dense,FixedProbability
 from ml_genn.initializers import Normal
 from ml_genn.neurons import LeakyIntegrate, LeakyIntegrateFire, SpikeInput
 from ml_genn.optimisers import Adam
+from ml_genn.regularisers import SpikeCount
 from ml_genn.serialisers import Numpy
 from ml_genn.synapses import Exponential
 from tonic.datasets import SHD
@@ -203,8 +204,9 @@ max_example_timesteps = int(np.ceil(latest_spike_time / DT))
 
 compiler = EventPropCompiler(example_timesteps=max_example_timesteps,
                              losses="sparse_categorical_crossentropy",
-                             reg_lambda=5e-11, reg_nu_upper=14, max_spikes=1500, batch_size=BATCH_SIZE)
-compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(0.001 * 0.01)}})
+                             max_spikes=1500, batch_size=BATCH_SIZE)
+compiled_net = compiler.compile(network, optimisers={"all_connections": {"weight": Adam(0.001 * 0.01)}},
+                                regularisers={"all_populations": SpikeCount(5e-11, 14)})
 best_acc, best_e = 0, 0
 with compiled_net:
     # Loop through epochs

--- a/ml_genn/ml_genn/__init__.py
+++ b/ml_genn/ml_genn/__init__.py
@@ -15,6 +15,7 @@ from . import metrics
 from . import neurons
 from . import optimisers
 from . import readouts
+from . import regularisers
 from . import serialisers
 from . import synapses
 from . import utils
@@ -24,4 +25,5 @@ __version__ = metadata.version("ml_genn")
 __all__ = ["Connection", "InputLayer", "Layer", "Network", "Population",
            "SequentialNetwork", "callbacks", "communicators", "compilers",
            "connectivity", "initializers", "losses", "metrics", "neurons",
-           "optimisers", "readouts", "serialisers", "synapses", "utils"]
+           "optimisers", "readouts", "regularisers", "serialisers",
+           "synapses", "utils"]

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -1770,7 +1770,7 @@ class EventPropCompiler(Compiler):
                 # **NOTE** this is multiplied by batch_size so it
                 # can be compared directly to SpikeCountBackBatch
                 genn_model.add_param("RegNuUpperBatch", "int",
-                                     regulariser.target * self.full_batch_size)
+                                     reg.target * self.full_batch_size)
                 # If batch size is 1, add reset variables to copy SpikeCount
                 # into SpikeCountBackBatch and zero SpikeCount
                 if self.full_batch_size == 1:

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -708,9 +708,12 @@ class EventPropCompiler(Compiler):
         # If none is provided, default to no regularisation
         regularisers = kwargs.get("regularisers", {})
                                        
-        # Check dictionary has been provided
+        # Check dictionaries have been provided
         if not isinstance(optimisers, Mapping):
             raise RuntimeError("'optimisers' should be "
+                               "specified as a dictionary")
+        if not isinstance(regularisers, Mapping):
+            raise RuntimeError("'regularisers' should be "
                                "specified as a dictionary")
 
         return CompileState(network, self.losses, optimisers,

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -421,7 +421,7 @@ class CompileState:
 
             # Otherwise, if key isn't one of the shortcut strings
             # which have already been processed, give error
-            elif k != "all_populations":
+            elif key != "all_populations":
                 raise RuntimeError(f"Invalid key '{k}' used in "
                                    f"'regularisers' dictionary. "
                                    f"Valid keys are Population or Layer "

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -26,6 +26,7 @@ from ..neurons import Input
 from ..optimisers import Optimiser
 from ..readouts import (AvgVar, AvgVarExpWeight, FirstSpikeTime,
                         EndVar, MaxVar, SumVar, Var, TimeWindowReadout)
+from ..regularisers import Regulariser, SpikeCount
 from ..utils.auto_model import AutoModel, AutoNeuronModel, AutoSynapseModel
 from ..utils.model import (CustomUpdateModel, Model, NeuronModel, 
                            SynapseModel, WeightUpdateModel)
@@ -44,7 +45,7 @@ from .compiler import (create_reset_custom_update, get_delay_type,
 from .deep_r import add_deep_r
 from ..utils.auto_tools import solve_ode
 from ..utils.module import get_object, get_object_mapping
-from ..utils.network import get_underlying_conn
+from ..utils.network import get_underlying_conn, get_underlying_pop
 from ..utils.value import is_value_constant
 
 from .compiler import softmax_1_model, softmax_2_model
@@ -310,7 +311,7 @@ def _get_var_connectivity_optimiser(n, o):
 
 class CompileState:
     def __init__(self, network: Network, losses, optimisers, 
-                 supported_matrix_type, backend_name):
+                 regularisers, supported_matrix_type, backend_name):
         self.backend_name = backend_name
         self._neuron_reset_vars = []
         self._synapse_reset_vars = []
@@ -322,6 +323,7 @@ class CompileState:
         self.update_trial_pops = []
         self.adjoint_limit_pops_vars = []
         self.optimisers = {}
+        self.regularisers = {}
         self.loss_recorder_populations = []
 
         # Build list of output populations
@@ -395,6 +397,35 @@ class CompileState:
                                    f"dictionary. Valid keys are Connection, "
                                    f"Population, InputLayer or Layer objects "
                                    f"Or strings such as 'all_connections'")
+
+        # If default regularisation settings for all populations
+        # has been provided, loop through all populations and 
+        # create regularisation objects
+        if "all_populations" in regularisers:
+            reg = regularisers["all_populations"]
+            for pop in network.populations:
+                self.regularisers[pop] = get_object(reg, Regulariser,
+                                                    "Regulariser",
+                                                    default_regularisers)
+        
+        # Loop through keys and configurations
+        for key, reg in regularisers.items():
+            # If key is a population or layer
+            if isinstance(key, (Population, Layer)):
+                # Lower key to Population
+                pop = get_underlying_pop(key)
+                self.regularisers[pop] = get_object(reg, Regulariser,
+                                                    "Regulariser",
+                                                    default_regularisers)
+
+            # Otherwise, if key isn't one of the shortcut strings
+            # which have already been processed, give error
+            elif k != "all_populations":
+                raise RuntimeError(f"Invalid key '{k}' used in "
+                                   f"'regularisers' dictionary. "
+                                   f"Valid keys are Population or Layer "
+                                   f"objects or strings such as 'all_populations'")
+
 
     def add_neuron_reset_vars(self, pop, reset_vars, 
                               reset_event_ring, reset_v_ring):
@@ -585,11 +616,6 @@ class EventPropCompiler(Compiler):
         losses:                     Either a dictionary mapping loss functions
                                     to output populations or a single loss
                                     function to apply to all outputs
-        reg_lambda:                 Regularisation strength, single value or tuple,
-                                    if tuple, (strength for undershoot of hidden
-                                    spike number, strength for overshoot)
-        reg_nu_upper:               Target number of hidden neuron
-                                    spikes used for regularisation
         grad_limit:                 TODO
         max_spikes:                 What is the maximum number of spikes each
                                     neuron (input and hidden) can emit each
@@ -626,9 +652,8 @@ class EventPropCompiler(Compiler):
     """
 
     def __init__(self, example_timesteps: int, losses,
-                 reg_lambda: Union[float, Tuple[float, float]] = 0.0,
-                 reg_nu_upper: float = 0.0, grad_limit: float = 100.0,
-                 max_spikes: int = 500, strict_buffer_checking: bool = False,
+                 grad_limit: float = 100.0, max_spikes: int = 500, 
+                 strict_buffer_checking: bool = False,
                  per_timestep_loss: bool = False, dt: float = 1.0,
                  ttfs_alpha: float = 0.01, softmax_temperature: float = 1.0,
                  batch_size: int = 1, rng_seed: int = 0, kernel_profiling: bool = False, 
@@ -648,28 +673,15 @@ class EventPropCompiler(Compiler):
                                "{\"weight\": \"adam\"} to optimise all "
                                "weights with the adam optimiser")
 
-        # If regularisation strength is specified as a single float, use for both upper and lower
-        if isinstance(reg_lambda, float):
-            self.reg_lambda_lower = reg_lambda
-            self.reg_lambda_upper = reg_lambda
-        # Otherwise, unpack
-        else:
-            self.reg_lambda_lower, self.reg_lambda_upper = reg_lambda
-
         # Handle legacy regularisation strength definitions
-        reg_warning = False
-        if "reg_lambda_lower" in genn_kwargs:
-            self.reg_lambda_lower = genn_kwargs.pop("reg_lambda_lower")
-            reg_warning = True
-        if "reg_lambda_upper" in genn_kwargs:
-            self.reg_lambda_upper = genn_kwargs.pop("reg_lambda_upper")
-            reg_warning = True
-        if reg_warning:
-             warn("Seperate 'reg_lambda_upper' and 'reg_lambda_lower' "
-                  "arguments for EventPropCompiler are no longer "
-                  "supported, please use 'reg_lambda' and use a "
-                  "tuple if separate values for undershoot "
-                  "and overshoot are required.", FutureWarning)
+        if "reg_lambda_lower" in genn_kwargs or "reg_lambda_upper" in genn_kwargs:
+             raise RuntimeError("The 'reg_lambda_lower' and 'reg_lambda_upper' "
+                                "parameters have been removed from the "
+                                "EventPropCompiler constructor. Regularisers "
+                                "are now specified by passing a 'regularisers' "
+                                "keyword argument to the ``compile`` method "
+                                "e.g. regularisers={\"all_connections\": "
+                                "SpikeCount(strength=0.01, target=1)}")
 
         super().__init__(supported_matrix_types, dt, batch_size, rng_seed,
                          kernel_profiling, communicator, **genn_kwargs)
@@ -691,14 +703,18 @@ class EventPropCompiler(Compiler):
         # to training all weights using the adam optimiser with default params
         optimisers = kwargs.get("optimisers", 
                                 {"all_connections": {"weight": "adam"}})
-    
+        
+        # Get base dictionary of regularisers. 
+        # If none is provided, default to no regularisation
+        regularisers = kwargs.get("regularisers", {})
+                                       
         # Check dictionary has been provided
         if not isinstance(optimisers, Mapping):
             raise RuntimeError("'optimisers' should be "
                                "specified as a dictionary")
 
         return CompileState(network, self.losses, optimisers,
-                            self.supported_matrix_type, 
+                            regularisers, self.supported_matrix_type,
                             genn_model.backend_name)
 
     def apply_delay(self, genn_pop, conn: Connection,
@@ -1681,9 +1697,16 @@ class EventPropCompiler(Compiler):
             
             # Build adjoint system from model
             learn_params = compile_state.optimisers.get(pop, {})
-            regularise = (self.reg_lambda_lower != 0.0) or (self.reg_lambda_upper != 0.0)
+            reg = compile_state.regularisers.get(pop, None)
             dl_dt, adjoint_jumps, grad_terms, saved_vars_timestep, saved_vars_spike =\
-                self._build_adjoint_system(model, learn_params, False, regularise)
+                self._build_adjoint_system(model, learn_params, False, 
+                                           reg is not None)
+
+            # Check regulariser is compatible with eventprop
+            if not isinstance(reg, SpikeCount):
+                 raise NotImplementedError(
+                    f"EventProp compiler doesn't support "
+                    f"{type(reg).__name__} regularisers")
 
             additional_reset_vars = []
             # Add variables for parameter gradients
@@ -1729,8 +1752,7 @@ class EventPropCompiler(Compiler):
                 genn_model.add_var(lambda_sym.name, "scalar", 0.0)
 
             # If regularisation is enabled
-            # **THINK** is this LIF-specific?
-            if regularise and model.threshold != 0:
+            if reg is not None and model.threshold != 0:
                 logger.debug("\tBuilding regulariser")
                 # Add state variables to hold spike count
                 # during forward and backward pass. 
@@ -1748,7 +1770,7 @@ class EventPropCompiler(Compiler):
                 # **NOTE** this is multiplied by batch_size so it
                 # can be compared directly to SpikeCountBackBatch
                 genn_model.add_param("RegNuUpperBatch", "int",
-                                     self.reg_nu_upper * self.full_batch_size)
+                                     regulariser.target * self.full_batch_size)
                 # If batch size is 1, add reset variables to copy SpikeCount
                 # into SpikeCountBackBatch and zero SpikeCount
                 if self.full_batch_size == 1:
@@ -1765,10 +1787,10 @@ class EventPropCompiler(Compiler):
                 scalar drive_reg;
                 const scalar spikeDev = (SpikeCountBackBatch - RegNuUpperBatch);
                 if (spikeDev > 0.0) {{
-                    drive_reg = -{self.reg_lambda_upper/self.full_batch_size/self.full_batch_size} * spikeDev;
+                    drive_reg = -{reg.strength_upper/self.full_batch_size/self.full_batch_size} * spikeDev;
                 }}
                 else {{
-                    drive_reg = -{self.reg_lambda_lower/self.full_batch_size/self.full_batch_size} * spikeDev;
+                    drive_reg = -{reg.strength_lower/self.full_batch_size/self.full_batch_size} * spikeDev;
                 }}
                 """
 

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -663,8 +663,9 @@ class EventPropCompiler(Compiler):
                                   SynapseMatrixType.PROCEDURAL_KERNELG,
                                   SynapseMatrixType.DENSE,
                                   SynapseMatrixType.SPARSE]
-        
-        if "optimiser" in genn_kwargs or "delay_optimiser" in genn_kwargs:
+
+        # Handle legacy optimiser definitions
+        if any(l in genn_kwargs for l in ("optimiser", "delay_optimiser")):
             raise RuntimeError("The 'optimiser' and 'delay_optimiser' "
                                "parameters have been removed from the "
                                "EventPropCompiler constructor. Optimisers "
@@ -675,13 +676,15 @@ class EventPropCompiler(Compiler):
                                "weights with the adam optimiser")
 
         # Handle legacy regularisation strength definitions
-        if "reg_lambda_lower" in genn_kwargs or "reg_lambda_upper" in genn_kwargs:
-             raise RuntimeError("The 'reg_lambda_lower' and 'reg_lambda_upper' "
-                                "parameters have been removed from the "
-                                "EventPropCompiler constructor. Regularisers "
-                                "are now specified by passing a 'regularisers' "
-                                "keyword argument to the ``compile`` method "
-                                "e.g. regularisers={\"all_connections\": "
+        if any(l in genn_kwargs 
+               for l in ("reg_lambda_lower", "reg_lambda_upper", "reg_nu_upper")):
+             raise RuntimeError("The 'reg_lambda_lower', 'reg_lambda_upper' "
+                                "and 'reg_nu_upper' parameters have been "
+                                "removed from the EventPropCompiler "
+                                "constructor. Regularisers are now specified "
+                                "by passing a 'regularisers' keyword argument"
+                                " to the ``compile`` method e.g. "
+                                "regularisers={\"all_connections\": "
                                 "SpikeCount(strength=0.01, target=1)}")
 
         super().__init__(supported_matrix_types, dt, batch_size, rng_seed,

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -402,8 +402,8 @@ class CompileState:
         # If default regularisation settings for all populations
         # has been provided, loop through all populations and 
         # create regularisation objects
-        if "all_populations" in regularisers:
-            reg = regularisers["all_populations"]
+        if "all_hidden_populations" in regularisers:
+            reg = regularisers["all_hidden_populations"]
             for pop in network.populations:
                 self.regularisers[pop] = get_object(reg, Regulariser,
                                                     "Regulariser",
@@ -421,11 +421,11 @@ class CompileState:
 
             # Otherwise, if key isn't one of the shortcut strings
             # which have already been processed, give error
-            elif key != "all_populations":
+            elif key != "all_hidden_populations":
                 raise RuntimeError(f"Invalid key '{key}' used in "
                                    f"'regularisers' dictionary. "
                                    f"Valid keys are Population or Layer "
-                                   f"objects or strings such as 'all_populations'")
+                                   f"objects or strings such as 'all_hidden_populations'")
 
 
     def add_neuron_reset_vars(self, pop, reset_vars, 
@@ -684,7 +684,7 @@ class EventPropCompiler(Compiler):
                                 "constructor. Regularisers are now specified "
                                 "by passing a 'regularisers' keyword argument"
                                 " to the ``compile`` method e.g. "
-                                "regularisers={\"all_populations\": "
+                                "regularisers={\"all_hidden_populations\": "
                                 "SpikeCount(strength=0.01, target=1)}")
 
         super().__init__(supported_matrix_types, dt, batch_size, rng_seed,

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -422,7 +422,7 @@ class CompileState:
             # Otherwise, if key isn't one of the shortcut strings
             # which have already been processed, give error
             elif key != "all_populations":
-                raise RuntimeError(f"Invalid key '{k}' used in "
+                raise RuntimeError(f"Invalid key '{key}' used in "
                                    f"'regularisers' dictionary. "
                                    f"Valid keys are Population or Layer "
                                    f"objects or strings such as 'all_populations'")

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -684,7 +684,7 @@ class EventPropCompiler(Compiler):
                                 "constructor. Regularisers are now specified "
                                 "by passing a 'regularisers' keyword argument"
                                 " to the ``compile`` method e.g. "
-                                "regularisers={\"all_connections\": "
+                                "regularisers={\"all_populations\": "
                                 "SpikeCount(strength=0.01, target=1)}")
 
         super().__init__(supported_matrix_types, dt, batch_size, rng_seed,

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -53,6 +53,7 @@ from .ground_truths import default_ground_truths
 from ..connectivity_optimisers import default_connectivity_optimisers
 from ..optimisers import default_optimisers
 from ..losses import default_losses
+from ..regularisers import default_regularisers
 
 logger = logging.getLogger(__name__)
 
@@ -1702,7 +1703,7 @@ class EventPropCompiler(Compiler):
                                            reg is not None)
 
             # Check regulariser is compatible with eventprop
-            if not isinstance(reg, SpikeCount):
+            if reg is not None and not isinstance(reg, SpikeCount):
                  raise NotImplementedError(
                     f"EventProp compiler doesn't support "
                     f"{type(reg).__name__} regularisers")

--- a/ml_genn/ml_genn/compilers/event_prop_compiler.py
+++ b/ml_genn/ml_genn/compilers/event_prop_compiler.py
@@ -688,7 +688,6 @@ class EventPropCompiler(Compiler):
 
         self.example_timesteps = example_timesteps
         self.losses = losses
-        self.reg_nu_upper = reg_nu_upper
         self.grad_limit = grad_limit
         self.max_spikes = max_spikes
         self.strict_buffer_checking = strict_buffer_checking
@@ -1779,7 +1778,7 @@ class EventPropCompiler(Compiler):
 
                 # Calculate regularisation drive
                 # We divide by batch size by formulation of the loss function and then again to take into consideration that
-                # SpikeCountBackBatch is collected across a batch; but then we multiply by reg_nu_upper times batch size
+                # SpikeCountBackBatch is collected across a batch; but then we multiply by target times batch size
                 # to normalise the effect of dividing by SpikeCountBackBatch.
                 # The division by SpikeCountBackBatch is motivated by the observation that the drive_reg is applied
                 # number of spike times, which biases regularisation towards suppressing too many spikes over enhancing to few

--- a/ml_genn/ml_genn/regularisers/__init__.py
+++ b/ml_genn/ml_genn/regularisers/__init__.py
@@ -1,0 +1,10 @@
+"""Regularisers are used to control neuron dynamics during training"""
+from .regulariser import Regulariser
+from .spike_count import SpikeCount
+
+from ..utils.module import get_module_classes
+
+default_regularisers = get_module_classes(globals(), Regulariser)
+
+__all__ = ["Regulariser", "SpikeCount",
+           "default_regularisers"]

--- a/ml_genn/ml_genn/regularisers/regulariser.py
+++ b/ml_genn/ml_genn/regularisers/regulariser.py
@@ -1,0 +1,2 @@
+class Regulariser:
+    pass

--- a/ml_genn/ml_genn/regularisers/spike_count.py
+++ b/ml_genn/ml_genn/regularisers/spike_count.py
@@ -12,13 +12,17 @@ class SpikeCount(Regulariser):
         target:     Target number of spikes"""
     def __init__(self, strength: Union[float, Tuple[float, float]],
                  target: float):
-        self.target = target
+        self.target = float(target)
         
-        # If strength is specified as a single 
-        # float, use for both upper and lower
-        if isinstance(strength, Number):
+        # Try and unpack tuple of strengths
+        try:
+            self.strength_lower, self.strength_upper = strength
+        # If it's not unpackable, use strength for lower and upper
+        # **NOTE** ValueErrors relating to wrong number of values still propagate
+        except TypeError:
             self.strength_lower = strength
             self.strength_upper = strength
-        # Otherwise, unpack
-        else:
-            self.strength_lower, self.strength_upper = strength
+        
+        # Ensure strengths are convertable to float
+        self.strength_lower = float(self.strength_lower)
+        self.strength_upper = float(self.strength_upper)

--- a/ml_genn/ml_genn/regularisers/spike_count.py
+++ b/ml_genn/ml_genn/regularisers/spike_count.py
@@ -1,3 +1,4 @@
+from numbers import Number
 from typing import Tuple, Union
 from .regulariser import Regulariser
 
@@ -15,7 +16,7 @@ class SpikeCount(Regulariser):
         
         # If strength is specified as a single 
         # float, use for both upper and lower
-        if isinstance(strength, float):
+        if isinstance(strength, Number):
             self.strength_lower = strength
             self.strength_upper = strength
         # Otherwise, unpack

--- a/ml_genn/ml_genn/regularisers/spike_count.py
+++ b/ml_genn/ml_genn/regularisers/spike_count.py
@@ -1,0 +1,23 @@
+from typing import Tuple, Union
+from .regulariser import Regulariser
+
+
+class SpikeCount(Regulariser):
+    """Implementation of a regulariser based on neuron spike count
+    Args:
+        strength:   Regularisation strength, single value or tuple,
+                    if tuple, (strength for undershoot of hidden
+                    spike number, strength for overshoot)
+        target:     Target number of spikes"""
+    def __init__(self, strength: Union[float, Tuple[float, float]],
+                 target: float):
+        self.target = target
+        
+        # If strength is specified as a single 
+        # float, use for both upper and lower
+        if isinstance(strength, float):
+            self.strength_lower = strength
+            self.strength_upper = strength
+        # Otherwise, unpack
+        else:
+            self.strength_lower, self.strength_upper = strength


### PR DESCRIPTION
Following the same basic design pattern as #195, you can now control regularisation strength per-layer with the ``regularisers`` keyword argument to ``EventPropCompiler.compile``:

```python
regularisers={"all_populations": SpikeCount(strength=1e-10, target=14)}
...
regularisers={hidden: SpikeCount(strength=1e-10, target=14)}
```

Like with Deep-R, this also means that the implementation _should_ move into the classes itself but as we're lacking in any other regularisers, it's not clear enough to me what the abstract interface should look like