### PR TITLE
prefer_in_memory

### DIFF
--- a/docs/usage/bibliography.rst
+++ b/docs/usage/bibliography.rst
@@ -8,4 +8,5 @@ Bibliography
 .. [Kriener2021] Kriener, L., Göltz, J., & Petrovici, M. A. (2021). The Yin-Yang dataset. 2–7.
 .. [Nowotny2024] Nowotny, T., Turner, J. P., & Knight, J. C. (2022). Loss shaping enhances exact gradient learning with EventProp in Spiking Neural Networks (arXiv:2212.01232). arXiv. http://arxiv.org/abs/2212.01232
 .. [Stockl2021] Stöckl, C., & Maass, W. (2021). Optimized spiking neurons can classify images with high accuracy through temporal coding with two spikes. Nature Machine Intelligence, 3(3), 230–238. https://doi.org/10.1038/s42256-021-00311-4
+.. [Turner2022] Turner, J. P., Knight, J. C., Subramanian, A., & Nowotny, T. (2022). mlGeNN: accelerating SNN inference using GPU-enabled neural networks. Neuromorphic Computing and Engineering, 2(2), 024002. https://doi.org/10.1088/2634-4386/ac5ac5
 .. [Wunderlich2021] Wunderlich, T. C., & Pehle, C. (2021). Event-based backpropagation can compute exact gradients for spiking neural networks. Scientific Reports, 11(1), 12829. https://doi.org/10.1038/s41598-021-91786-z

--- a/examples/tf/arguments.py
+++ b/examples/tf/arguments.py
@@ -25,7 +25,7 @@ def parse_arguments(model_description="ML GeNN model"):
     parser.add_argument("--batch-size", type=int, default=1)
     parser.add_argument("--input-type", default="poisson",
                         choices=[i.value for i in InputType])
-    parser.add_argument("--prefer-in-memory-connect", action="store_true")
+    parser.add_argument("--optimise-connectivity-speed", action="store_true")
     parser.add_argument("--kernel-profiling", action="store_true")
 
     # ANN conversion options

--- a/examples/tf/resnet20_cifar10.py
+++ b/examples/tf/resnet20_cifar10.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
     mlg_net, mlg_net_inputs, mlg_net_outputs = converter.convert(tf_model)
 
     # Create suitable compiler for model
-    compiler = converter.create_compiler(prefer_in_memory_connect=args.prefer_in_memory_connect,
+    compiler = converter.create_compiler(optimise_connectivity_speed=args.optimise_connectivity_speed,
                                          dt=args.dt, batch_size=args.batch_size, rng_seed=args.rng_seed, 
                                          kernel_profiling=args.kernel_profiling)
     compiled_net = compiler.compile(mlg_net, inputs=mlg_net_inputs, 

--- a/examples/tf/resnet34_imagenet.py
+++ b/examples/tf/resnet34_imagenet.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
                                   example_filter=args.plot_sample_spikes))
 
     # Create suitable compiler for model
-    compiler = converter.create_compiler(prefer_in_memory_connect=args.prefer_in_memory_connect,
+    compiler = converter.create_compiler(optimise_connectivity_speed=args.optimise_connectivity_speed,
                                          dt=args.dt, batch_size=args.batch_size, rng_seed=args.rng_seed, 
                                          kernel_profiling=args.kernel_profiling)
     compiled_net = compiler.compile(net, inputs=net_inputs, 

--- a/examples/tf/simple_cnn.py
+++ b/examples/tf/simple_cnn.py
@@ -80,7 +80,7 @@ if len(args.plot_sample_spikes) > 0:
             tf_layer_pops[l].record_spikes = True
     
 # Create suitable compiler for model
-compiler = converter.create_compiler(prefer_in_memory_connect=args.prefer_in_memory_connect,
+compiler = converter.create_compiler(optimise_connectivity_speed=args.optimise_connectivity_speed,
                                      dt=args.dt, batch_size=args.batch_size, rng_seed=args.rng_seed, 
                                      kernel_profiling=args.kernel_profiling)
 compiled_net = compiler.compile(net, inputs=net_inputs, outputs=net_outputs)

--- a/examples/tf/vgg16_cifar10.py
+++ b/examples/tf/vgg16_cifar10.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
                                   example_filter=args.plot_sample_spikes))
 
     # Create suitable compiler for model
-    compiler = converter.create_compiler(prefer_in_memory_connect=args.prefer_in_memory_connect,
+    compiler = converter.create_compiler(optimise_connectivity_speed=args.optimise_connectivity_speed,
                                          dt=args.dt, batch_size=args.batch_size, rng_seed=args.rng_seed, 
                                          kernel_profiling=args.kernel_profiling)
     compiled_net = compiler.compile(net, inputs=net_inputs, 

--- a/examples/tf/vgg16_imagenet.py
+++ b/examples/tf/vgg16_imagenet.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
                                   example_filter=args.plot_sample_spikes))
 
     # Create suitable compiler for model
-    compiler = converter.create_compiler(prefer_in_memory_connect=args.prefer_in_memory_connect,
+    compiler = converter.create_compiler(optimise_connectivity_speed=args.optimise_connectivity_speed,
                                          dt=args.dt, batch_size=args.batch_size, rng_seed=args.rng_seed, 
                                          kernel_profiling=args.kernel_profiling)
     compiled_net = compiler.compile(net, inputs=net_inputs, 

--- a/ml_genn/ml_genn/compilers/few_spike_compiler.py
+++ b/ml_genn/ml_genn/compilers/few_spike_compiler.py
@@ -196,21 +196,25 @@ CompileState = namedtuple("CompileState",
 class FewSpikeCompiler(Compiler):
     def __init__(self, k: int = 10, dt: float = 1.0, batch_size: int = 1,
                  rng_seed: int = 0, kernel_profiling: bool = False,
-                 prefer_in_memory_connect: bool = True,
+                 optimise_connectivity_speed: bool = False,
                  communicator: Communicator = None, **genn_kwargs):
-        # Determine matrix type order of preference based on flag
-        if prefer_in_memory_connect:
-            supported_matrix_type = [SynapseMatrixType.SPARSE,
-                                     SynapseMatrixType.DENSE,
-                                     SynapseMatrixType.TOEPLITZ,
-                                     SynapseMatrixType.PROCEDURAL_KERNELG,
-                                     SynapseMatrixType.PROCEDURAL]
+        # Determine matrix type order of preference based on flag. 'Toeplitz' 
+        # implementations are nearly always fastest *and* use the least memory
+        # but, while sparse and dense are often faster than 'procedural', they
+        # use (often significantly) more memory  [Turner2022]_
+        if optimise_connectivity_speed:
+            supported_matrix_type = [SynapseMatrixType.TOEPLITZ,
+                                        SynapseMatrixType.SPARSE,
+                                        SynapseMatrixType.DENSE,
+                                        SynapseMatrixType.PROCEDURAL_KERNELG,
+                                        SynapseMatrixType.PROCEDURAL]
         else:
             supported_matrix_type = [SynapseMatrixType.TOEPLITZ,
-                                     SynapseMatrixType.PROCEDURAL_KERNELG,
-                                     SynapseMatrixType.PROCEDURAL,
-                                     SynapseMatrixType.SPARSE,
-                                     SynapseMatrixType.DENSE]
+                                        SynapseMatrixType.PROCEDURAL_KERNELG,
+                                        SynapseMatrixType.PROCEDURAL,
+                                        SynapseMatrixType.SPARSE,
+                                        SynapseMatrixType.DENSE]
+
         super().__init__(supported_matrix_type, dt, batch_size, rng_seed,
                          kernel_profiling, communicator, **genn_kwargs)
         self.k = k

--- a/ml_genn/ml_genn/compilers/inference_compiler.py
+++ b/ml_genn/ml_genn/compilers/inference_compiler.py
@@ -355,10 +355,10 @@ class InferenceCompiler(Compiler):
                                         model which can be  accessed via the
                                         ``genn_model`` property of 
                                         the compiled model.
-        prefer_in_memory_connect:       Should in-memory connectivity
-                                        strategies such as TOEPLITZ be used
-                                        rather than converting all
-                                        connectivity into matrices.
+        optimise_connectivity_speed:    Some forms of connectivity can be
+                                        implemented in multiple ways. This
+                                        flag will prioritise speed over GPU
+                                        memory usage
         reset_time_between_batches:     Should time be reset to zero at the 
                                         start of each example or allowed to
                                         run continously? 
@@ -377,18 +377,21 @@ class InferenceCompiler(Compiler):
     def __init__(self, evaluate_timesteps: int, dt: float = 1.0,
                  batch_size: int = 1, rng_seed: int = 0,
                  kernel_profiling: bool = False,
-                 prefer_in_memory_connect=True, 
+                 optimise_connectivity_speed=False, 
                  reset_time_between_batches=True,
                  reset_vars_between_batches=True,
                  reset_in_syn_between_batches=False,
                  communicator: Communicator = None,
                  **genn_kwargs):
 
-        # Determine matrix type order of preference based on flag
-        if prefer_in_memory_connect:
-            supported_matrix_type = [SynapseMatrixType.SPARSE,
+        # Determine matrix type order of preference based on flag. 'Toeplitz' 
+        # implementations are nearly always fastest *and* use the least memory
+        # but, while sparse and dense are often faster than 'procedural', they
+        # use (often significantly) more memory  [Turner2022]_
+        if optimise_connectivity_speed:
+            supported_matrix_type = [SynapseMatrixType.TOEPLITZ,
+                                     SynapseMatrixType.SPARSE,
                                      SynapseMatrixType.DENSE,
-                                     SynapseMatrixType.TOEPLITZ,
                                      SynapseMatrixType.PROCEDURAL_KERNELG,
                                      SynapseMatrixType.PROCEDURAL]
         else:

--- a/tests/ml_genn_tf/test_avg_pool_2d.py
+++ b/tests/ml_genn_tf/test_avg_pool_2d.py
@@ -4,7 +4,7 @@ import pytest
 from .converter import Converter
 
 @pytest.mark.parametrize(
-    "in_size, in_chan, pool_size, pool_strides, prefer_in_memory_connect", 
+    "in_size, in_chan, pool_size, pool_strides, optimise_connectivity_speed", 
     [(20, 1, 2, 2, True),
      (20, 1, 2, 2, False),
      (20, 2, 2, 2, True),
@@ -14,7 +14,7 @@ from .converter import Converter
      (20, 1, 2, 3, True),
      (20, 1, 2, 3, False)])
 def test_avg_pool_2d(in_size, in_chan, pool_size, pool_strides, 
-                   prefer_in_memory_connect, request):
+                   optimise_connectivity_speed, request):
     # Don't use all GPU memory for TF!
     for gpu in tf.config.experimental.list_physical_devices("GPU"):
         tf.config.experimental.set_memory_growth(gpu, True)
@@ -37,7 +37,7 @@ def test_avg_pool_2d(in_size, in_chan, pool_size, pool_strides,
     converter = Converter()
     net, net_inputs, net_outputs, tf_layer_pops = converter.convert(tf_model)
     
-    compiler = converter.create_compiler(prefer_in_memory_connect=prefer_in_memory_connect)
+    compiler = converter.create_compiler(optimise_connectivity_speed=optimise_connectivity_speed)
     compiled_net = compiler.compile(net, request.keywords.node.name, 
                                     inputs=net_inputs, 
                                     outputs=net_outputs)

--- a/tests/ml_genn_tf/test_avg_pool_conv_2d.py
+++ b/tests/ml_genn_tf/test_avg_pool_conv_2d.py
@@ -4,7 +4,7 @@ import pytest
 from .converter import Converter
 
 @pytest.mark.parametrize(
-    "in_size, in_chan, out_chan, pool_size, pool_strides, conv_size, conv_strides, conv_padding, prefer_in_memory_connect", 
+    "in_size, in_chan, out_chan, pool_size, pool_strides, conv_size, conv_strides, conv_padding, optimise_connectivity_speed", 
     [(20, 1, 1, 2, 2, 3, 1, "valid", True),
      (20, 1, 1, 2, 2, 3, 1, "valid", False),
      (20, 2, 2, 2, 2, 3, 1, "valid", True),
@@ -23,7 +23,7 @@ from .converter import Converter
      (20, 1, 1, 3, 4, 4, 1, "same", False)])
 def test_avg_pool_conv_2d(in_size, in_chan, out_chan, pool_size, pool_strides,
                           conv_size, conv_strides, conv_padding, 
-                          prefer_in_memory_connect, request):
+                          optimise_connectivity_speed, request):
     # Don't use all GPU memory for TF!
     for gpu in tf.config.experimental.list_physical_devices("GPU"):
         tf.config.experimental.set_memory_growth(gpu, True)
@@ -50,7 +50,7 @@ def test_avg_pool_conv_2d(in_size, in_chan, out_chan, pool_size, pool_strides,
     converter = Converter()
     net, net_inputs, net_outputs, tf_layer_pops = converter.convert(tf_model)
     
-    compiler = converter.create_compiler(prefer_in_memory_connect=prefer_in_memory_connect)
+    compiler = converter.create_compiler(optimise_connectivity_speed=optimise_connectivity_speed)
     compiled_net = compiler.compile(net, request.keywords.node.name, 
                                     inputs=net_inputs, 
                                     outputs=net_outputs)

--- a/tests/ml_genn_tf/test_avg_pool_dense_2d.py
+++ b/tests/ml_genn_tf/test_avg_pool_dense_2d.py
@@ -5,7 +5,7 @@ import pytest
 from .converter import Converter
 
 @pytest.mark.parametrize(
-    "in_size, in_chan, out_size, pool_size, pool_strides, prefer_in_memory_connect", 
+    "in_size, in_chan, out_size, pool_size, pool_strides, optimise_connectivity_speed", 
     [(20, 1, 10, 2, 2, True),
      (20, 1, 10, 2, 2, False),
      (20, 2, 10, 2, 2, True),
@@ -15,7 +15,7 @@ from .converter import Converter
      (20, 1, 10, 2, 3, True),
      (20, 1, 10, 2, 3, False)])
 def test_avg_pool_dense_2d(in_size, in_chan, out_size, pool_size,
-                           pool_strides, prefer_in_memory_connect, request):
+                           pool_strides, optimise_connectivity_speed, request):
     # Don"t use all GPU memory for TF!
     for gpu in tf.config.experimental.list_physical_devices("GPU"):
         tf.config.experimental.set_memory_growth(gpu, True)
@@ -43,7 +43,7 @@ def test_avg_pool_dense_2d(in_size, in_chan, out_size, pool_size,
     converter = Converter()
     net, net_inputs, net_outputs, tf_layer_pops = converter.convert(tf_model)
     
-    compiler = converter.create_compiler(prefer_in_memory_connect=prefer_in_memory_connect)
+    compiler = converter.create_compiler(optimise_connectivity_speed=optimise_connectivity_speed)
     compiled_net = compiler.compile(net, request.keywords.node.name, 
                                     inputs=net_inputs, 
                                     outputs=net_outputs)

--- a/tests/ml_genn_tf/test_conv_2d.py
+++ b/tests/ml_genn_tf/test_conv_2d.py
@@ -4,7 +4,7 @@ import pytest
 from .converter import Converter
 
 @pytest.mark.parametrize(
-    "in_size, in_chan, out_chan, conv_size, conv_strides, conv_padding, prefer_in_memory_connect", 
+    "in_size, in_chan, out_chan, conv_size, conv_strides, conv_padding, optimise_connectivity_speed", 
     [(12, 1, 1, 3, 1, "valid", True),
      (12, 1, 1, 3, 1, "valid", False),
      (12, 1, 1, 3, 1, "same", True),
@@ -21,7 +21,7 @@ from .converter import Converter
      (12, 1, 1, 3, 2, "same", False)])
 
 def test_conv_2d(in_size, in_chan, out_chan, conv_size, conv_strides,
-                 conv_padding, prefer_in_memory_connect, request):
+                 conv_padding, optimise_connectivity_speed, request):
     # Don't use all GPU memory for TF!
     for gpu in tf.config.experimental.list_physical_devices("GPU"):
         tf.config.experimental.set_memory_growth(gpu, True)
@@ -46,7 +46,7 @@ def test_conv_2d(in_size, in_chan, out_chan, conv_size, conv_strides,
     converter = Converter()
     net, net_inputs, net_outputs, tf_layer_pops = converter.convert(tf_model)
     
-    compiler = converter.create_compiler(prefer_in_memory_connect=prefer_in_memory_connect)
+    compiler = converter.create_compiler(optimise_connectivity_speed=optimise_connectivity_speed)
     compiled_net = compiler.compile(net, request.keywords.node.name, 
                                     inputs=net_inputs, 
                                     outputs=net_outputs)


### PR DESCRIPTION
* replaced previous weird ``prefer_in_memory`` flag to inference and few-spike compilers with ``optimise_connectivity_speed`` which better reflects its role and also has more sensibly ordered priority lists
* updated tests
* updated TF examples

``optimise_connectivity_speed`` remains a bit of a mouthful so would welcome terser suggestions!